### PR TITLE
Add excludeFiles configuration to CLI and update file listing logic

### DIFF
--- a/.polkacodes.yml
+++ b/.polkacodes.yml
@@ -12,6 +12,9 @@ commands:
     description: |
       Format the code and fix fixable linting issues.
       Run this command when linting issues are found.
+excludeFiles:
+  - .env
+  - packages/cli/cli.mjs
 rules: |
   Use `bun` as the package manager
   When adding new dependencies, cd to the package directory and run `bun add <dependency>`

--- a/packages/cli/src/Runner.ts
+++ b/packages/cli/src/Runner.ts
@@ -61,6 +61,7 @@ export class Runner {
             console.log(`$ <<<< $ Command error: ${error}`)
           },
         },
+        excludeFiles: options.config.excludeFiles,
       }),
       interactive: options.interactive,
     })
@@ -68,7 +69,7 @@ export class Runner {
 
   async startTask(task: string) {
     const cwd = process.cwd()
-    const [fileList, limited] = await listFiles(cwd, true, 100, cwd)
+    const [fileList, limited] = await listFiles(cwd, true, 100, cwd, this.#options.config.excludeFiles)
     const fileContext = `<files>
 ${fileList.join('\n')}${limited ? '\n<files_truncated>true</files_truncated>' : ''}
 </files>`

--- a/packages/cli/src/utils/listFiles.test.ts
+++ b/packages/cli/src/utils/listFiles.test.ts
@@ -28,7 +28,7 @@ describe('listFiles', () => {
   })
 
   it('should list files in directory', async () => {
-    const [files] = await listFiles(testDir, false, 10, testDir)
+    const [files] = await listFiles(testDir, false, 10, testDir, [])
     expect(files).toEqual(['.gitignore', 'file1.txt', 'file2.txt'])
   })
 

--- a/packages/cli/src/utils/listFiles.ts
+++ b/packages/cli/src/utils/listFiles.ts
@@ -50,9 +50,15 @@ function createIgnore(patterns: string[]): Ignore {
  *   - `files` is the array of file paths (relative to `cwd`)
  *   - `limitReached` is `true` if `maxCount` was hit, otherwise `false`
  */
-export async function listFiles(dirPath: string, recursive: boolean, maxCount: number, cwd: string): Promise<[string[], boolean]> {
-  // Merge default ignores with root .gitignore (if found)
-  let rootPatterns = [...DEFAULT_IGNORES]
+export async function listFiles(
+  dirPath: string,
+  recursive: boolean,
+  maxCount: number,
+  cwd: string,
+  excludeFiles?: string[],
+): Promise<[string[], boolean]> {
+  // Merge default ignores with root .gitignore and excludeFiles (if found)
+  let rootPatterns = [...DEFAULT_IGNORES, ...(excludeFiles || [])]
   try {
     const rootGitignore = await fs.readFile(join(cwd, '.gitignore'), 'utf8')
     const lines = rootGitignore.split(/\r?\n/).filter(Boolean)


### PR DESCRIPTION

This PR introduces a new `excludeFiles` configuration option in the CLI, allowing users to specify files to exclude during operations. The file listing logic has been updated to respect this configuration, ensuring excluded files are not processed. Changes include updates to the configuration schema, Runner, Provider, and listFiles utility to support this feature.
