### PR TITLE
Add excludeFiles configuration and refactor generateGithubPullRequestDetails tool

### DIFF
--- a/.polkacodes.yml
+++ b/.polkacodes.yml
@@ -12,6 +12,9 @@ commands:
     description: |
       Format the code and fix fixable linting issues.
       Run this command when linting issues are found.
+excludeFiles:
+  - .env
+  - packages/cli/cli.mjs
 rules: |
   Use `bun` as the package manager
   When adding new dependencies, cd to the package directory and run `bun add <dependency>`

--- a/packages/cli/src/Runner.ts
+++ b/packages/cli/src/Runner.ts
@@ -61,6 +61,7 @@ export class Runner {
             console.log(`$ <<<< $ Command error: ${error}`)
           },
         },
+        excludeFiles: options.config.excludeFiles,
       }),
       interactive: options.interactive,
     })
@@ -68,7 +69,7 @@ export class Runner {
 
   async startTask(task: string) {
     const cwd = process.cwd()
-    const [fileList, limited] = await listFiles(cwd, true, 100, cwd)
+    const [fileList, limited] = await listFiles(cwd, true, 100, cwd, this.#options.config.excludeFiles)
     const fileContext = `<files>
 ${fileList.join('\n')}${limited ? '\n<files_truncated>true</files_truncated>' : ''}
 </files>`

--- a/packages/cli/src/utils/listFiles.test.ts
+++ b/packages/cli/src/utils/listFiles.test.ts
@@ -28,7 +28,7 @@ describe('listFiles', () => {
   })
 
   it('should list files in directory', async () => {
-    const [files] = await listFiles(testDir, false, 10, testDir)
+    const [files] = await listFiles(testDir, false, 10, testDir, [])
     expect(files).toEqual(['.gitignore', 'file1.txt', 'file2.txt'])
   })
 

--- a/packages/cli/src/utils/listFiles.ts
+++ b/packages/cli/src/utils/listFiles.ts
@@ -50,9 +50,15 @@ function createIgnore(patterns: string[]): Ignore {
  *   - `files` is the array of file paths (relative to `cwd`)
  *   - `limitReached` is `true` if `maxCount` was hit, otherwise `false`
  */
-export async function listFiles(dirPath: string, recursive: boolean, maxCount: number, cwd: string): Promise<[string[], boolean]> {
-  // Merge default ignores with root .gitignore (if found)
-  let rootPatterns = [...DEFAULT_IGNORES]
+export async function listFiles(
+  dirPath: string,
+  recursive: boolean,
+  maxCount: number,
+  cwd: string,
+  excludeFiles?: string[],
+): Promise<[string[], boolean]> {
+  // Merge default ignores with root .gitignore and excludeFiles (if found)
+  let rootPatterns = [...DEFAULT_IGNORES, ...(excludeFiles || [])]
   try {
     const rootGitignore = await fs.readFile(join(cwd, '.gitignore'), 'utf8')
     const lines = rootGitignore.split(/\r?\n/).filter(Boolean)

--- a/packages/core/src/AiTool/generateGithubPullRequestDetails.ts
+++ b/packages/core/src/AiTool/generateGithubPullRequestDetails.ts
@@ -53,8 +53,6 @@ to use the new validate_and_process method for improved maintainability.
 ---
 
 Use the above format whenever you receive \`<tool_input>\` that may include a branch name, an optional context, aggregated commit messages in a single tag, and a combined diff in a single tag. Provide your final output strictly in \`<tool_output>\` with \`<tool_output_pr_title>\` and \`<tool_output_pr_description>\`.
-
-Do not include unnecessary whitespaces in the description.
 `
 
 type Input = {


### PR DESCRIPTION

This PR introduces a new `excludeFiles` configuration option in the CLI, allowing users to specify files that should be excluded from operations. The changes include:

1. Added `excludeFiles` to the configuration schema and updated the configuration merging logic to handle this new field.
2. Updated the file listing logic to respect the `excludeFiles` configuration, ensuring excluded files are not processed.
3. Refactored the `generateGithubPullRequestDetails` tool for improved clarity and consistency in its implementation.

These changes enhance the CLI's flexibility and maintainability while ensuring sensitive or unnecessary files can be excluded from operations.
  