### PR TITLE
Add DeepSeek Reasoner Model with Pricing and Configuration

### DIFF
--- a/packages/core/src/AiService/ModelInfo.ts
+++ b/packages/core/src/AiService/ModelInfo.ts
@@ -85,4 +85,14 @@ export const deepSeekModels = {
     cacheWritesPrice: 0.14,
     cacheReadsPrice: 0.014,
   },
+  'deepseek-reasoner': {
+    maxTokens: 8_000,
+    contextWindow: 64_000,
+    supportsImages: false,
+    supportsPromptCache: true,
+    inputPrice: 0,
+    outputPrice: 2.19,
+    cacheWritesPrice: 0.55,
+    cacheReadsPrice: 0.14,
+  },
 } as const satisfies Record<string, ModelInfo>


### PR DESCRIPTION

This PR introduces the DeepSeek Reasoner model to the `ModelInfo.ts` file, including its pricing and configuration details. The model supports a context window of 64,000 tokens, has a maximum token limit of 8,000, and does not support images. Pricing details include output price, cache writes price, and cache reads price. This addition aligns with the existing structure for other models like Anthropic and DeepSeek Chat.
