### PR TITLE
Add Reasoning Chunk Type and Handle Reasoning Content in DeepSeekService

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "packages/action": {
       "name": "@polka-codes/action",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@actions/core": "^1.11.1",
         "@actions/github": "^6.0.0",
@@ -24,13 +24,14 @@
     },
     "packages/cli": {
       "name": "@polka-codes/cli",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "bin": {
         "polka-codes": "cli.mjs"
       },
       "dependencies": {
         "@inquirer/prompts": "^7.2.3",
         "@polka-codes/core": "workspace:*",
+        "chalk": "^5.4.1",
         "commander": "^13.0.0",
         "dotenv": "^16.4.7",
         "ignore": "^7.0.3",
@@ -45,7 +46,7 @@
     },
     "packages/core": {
       "name": "@polka-codes/core",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.36.2",
         "openai": "^4.80.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@inquirer/prompts": "^7.2.3",
     "@polka-codes/core": "workspace:*",
+    "chalk": "^5.4.1",
     "commander": "^13.0.0",
     "dotenv": "^16.4.7",
     "ignore": "^7.0.3",

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -1,4 +1,5 @@
 import { type AiServiceProvider, ExitReason, type TaskInfo, defaultModels } from '@polka-codes/core'
+import chalk from 'chalk'
 import { Chat } from '../Chat'
 import { Runner } from '../Runner'
 import { parseOptions } from '../options'
@@ -32,7 +33,11 @@ export const runChat = async (options: any) => {
     interactive: true,
     eventCallback: (event) => {
       if (event.newText) {
-        process.stdout.write(event.newText)
+        if (event.kind === 'reasoning') {
+          process.stdout.write(chalk.dim(event.newText))
+        } else {
+          process.stdout.write(event.newText)
+        }
       }
       if (event.kind === 'end_request') {
         console.log('\n\n========\n')

--- a/packages/cli/src/commands/commit.ts
+++ b/packages/cli/src/commands/commit.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process'
 import { confirm } from '@inquirer/prompts'
 import { Command } from 'commander'
+import ora from 'ora'
 
 import { createService, generateGitCommitMessage } from '@polka-codes/core'
 import { parseOptions } from '../options'
@@ -10,7 +11,9 @@ export const commitCommand = new Command('commit')
   .option('-a, --all', 'Stage all files before committing')
   .argument('[message]', 'Optional context for the commit message generation')
   .action(async (message, options) => {
-    const { providerConfig, config } = parseOptions(options)
+    const spinner = ora('Gathering information...').start()
+
+    const { providerConfig } = parseOptions(options)
 
     const { provider, model, apiKey } = providerConfig.getConfigForCommand('commit') ?? {}
 
@@ -50,8 +53,12 @@ export const commitCommand = new Command('commit')
       // Get diff with 200 lines of context
       const diff = execSync('git diff --cached -U200').toString()
 
+      spinner.text = 'Generating commit message...'
+
       // Generate commit message
       const result = await generateGitCommitMessage(ai, { diff, context: message })
+
+      spinner.succeed('Commit message generated')
 
       // Make the commit
       try {

--- a/packages/cli/src/commands/pr.ts
+++ b/packages/cli/src/commands/pr.ts
@@ -1,8 +1,8 @@
 import { execSync, spawnSync } from 'node:child_process'
 import { createService, generateGithubPullRequestDetails } from '@polka-codes/core'
 import { Command } from 'commander'
-
 import ora from 'ora'
+
 import { parseOptions } from '../options'
 
 export const prCommand = new Command('pr')

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -1,4 +1,5 @@
 import { type AiServiceProvider, defaultModels } from '@polka-codes/core'
+import chalk from 'chalk'
 import { Runner } from '../Runner'
 import { parseOptions } from '../options'
 import { runChat } from './chat'
@@ -33,21 +34,15 @@ export const runTask = async (taskArg: string, options: any) => {
     maxIterations,
     interactive: false,
     eventCallback: (event) => {
-      if (event.kind === 'start_request') {
-        console.log('>>>>')
-        const { userMessage } = event
-        if (userMessage) {
-          console.log(userMessage)
-        }
-        console.log('====')
-      }
-
       if (event.newText) {
-        process.stdout.write(event.newText)
+        if (event.kind === 'reasoning') {
+          process.stdout.write(chalk.dim(event.newText))
+        } else {
+          process.stdout.write(event.newText)
+        }
       }
       if (event.kind === 'end_request') {
-        process.stdout.write('\n')
-        console.log('<<<<')
+        console.log('\n\n========\n')
       }
       if (event.kind === 'max_iterations_reached') {
         console.log('Max iterations reached')

--- a/packages/core/src/Agent/AgentBase.ts
+++ b/packages/core/src/Agent/AgentBase.ts
@@ -128,6 +128,9 @@ export abstract class AgentBase {
           currentAssistantMessage += chunk.text
           await callback({ kind: 'text', info, newText: chunk.text })
           break
+        case 'reasoning':
+          await callback({ kind: 'reasoning', info, newText: chunk.text })
+          break
       }
     }
 

--- a/packages/core/src/Agent/AgentBase.ts
+++ b/packages/core/src/Agent/AgentBase.ts
@@ -158,7 +158,7 @@ export abstract class AgentBase {
     callback: TaskEventCallback,
   ): Promise<[string | undefined, ExitReason | undefined]> {
     const toolReponses: { tool: string; response: string }[] = []
-    for (const content of response) {
+    outer: for (const content of response) {
       switch (content.type) {
         case 'text':
           // no need to handle text content
@@ -179,12 +179,12 @@ export abstract class AgentBase {
               // tell AI about the invalid arguments
               await callback({ kind: 'tool_invalid', info, tool: content.name })
               toolReponses.push({ tool: content.name, response: toolResp.message })
-              break
+              break outer
             case ToolResponseType.Error:
               // tell AI about the error
               await callback({ kind: 'tool_error', info, tool: content.name })
               toolReponses.push({ tool: content.name, response: toolResp.message })
-              break
+              break outer
             case ToolResponseType.Interrupted:
               // the execution is killed
               await callback({ kind: 'tool_interrupted', info, tool: content.name })

--- a/packages/core/src/AiService/AiServiceBase.ts
+++ b/packages/core/src/AiService/AiServiceBase.ts
@@ -2,10 +2,15 @@ import type { Anthropic } from '@anthropic-ai/sdk'
 
 import type { ModelInfo } from './ModelInfo'
 
-export type ApiStreamChunk = ApiStreamTextChunk | ApiStreamUsageChunk
+export type ApiStreamChunk = ApiStreamTextChunk | ApiStreamUsageChunk | ApiStreamReasoningTextChunk
 
 export interface ApiStreamTextChunk {
   type: 'text'
+  text: string
+}
+
+export interface ApiStreamReasoningTextChunk {
+  type: 'reasoning'
   text: string
 }
 
@@ -47,6 +52,7 @@ export abstract class AiServiceBase {
     }
 
     let resp = ''
+    let reasoning = ''
 
     for await (const chunk of stream) {
       switch (chunk.type) {
@@ -60,11 +66,14 @@ export abstract class AiServiceBase {
         case 'text':
           resp += chunk.text
           break
+        case 'reasoning':
+          reasoning += chunk.text
       }
     }
 
     return {
       response: resp,
+      reasoning,
       usage,
     }
   }

--- a/packages/core/src/AiService/DeepSeekService.ts
+++ b/packages/core/src/AiService/DeepSeekService.ts
@@ -42,6 +42,12 @@ export class DeepSeekService extends AiServiceBase {
     })
     for await (const chunk of stream) {
       const delta = chunk.choices[0]?.delta
+      if ((delta as any)?.reasoning_content) {
+        yield {
+          type: 'reasoning',
+          text: (delta as any).reasoning_content,
+        }
+      }
       if (delta?.content) {
         yield {
           type: 'text',


### PR DESCRIPTION
This PR introduces a new reasoning chunk type to `AiServiceBase` and handles reasoning content in `DeepSeekService`. The changes include updating the lockfile, modifying package versions, adding `chalk` as a dependency in the CLI, refactoring the chat command to differentiate between regular text and reasoning text, and enhancing the AI service to support reasoning chunks.
  