### PR TITLE
Refactor Config Merging and Trim Whitespace in PR Command

### DIFF
--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -174,9 +174,9 @@ export async function configCommand(options: { global?: boolean; print?: boolean
   }
 
   const newConfig = {
+    ...existingConfig,
     defaultProvider: provider,
     defaultModel: model,
-    ...existingConfig,
   }
   if (apiKey) {
     set(newConfig, ['providers', provider, 'apiKey'], apiKey)

--- a/packages/cli/src/commands/pr.ts
+++ b/packages/cli/src/commands/pr.ts
@@ -76,7 +76,7 @@ export const prCommand = new Command('pr')
 
       spinner.succeed('Pull request details generated')
 
-      spawnSync('gh', ['pr', 'create', '--title', prDetails.response.title, '--body', prDetails.response.description], {
+      spawnSync('gh', ['pr', 'create', '--title', prDetails.response.title.trim(), '--body', prDetails.response.description.trim()], {
         stdio: 'inherit',
       })
     } catch (error) {


### PR DESCRIPTION
This PR includes two main changes:
1. Refactors the config object merging logic to prioritize existing config properties, ensuring proper handling of default values.
2. Adds whitespace trimming to the pull request title and description in the `pr` command to prevent unnecessary whitespace in GitHub PRs.