### PR TITLE
Refactor Config Command to Use Commander and Improve Structure

### DIFF
--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -5,6 +5,7 @@ import { stringify } from 'yaml'
 
 import { AiServiceProvider, anthropicDefaultModelId, anthropicModels, deepSeekDefaultModelId } from '@polka-codes/core'
 
+import { Command } from 'commander'
 import { set } from 'lodash'
 import { getGlobalConfigPath, loadConfigAtPath, localConfigFileName } from '../config'
 
@@ -93,99 +94,102 @@ async function printConfig(configPath: string) {
   console.log(stringify(config))
 }
 
-export async function configCommand(options: { global?: boolean; print?: boolean }) {
-  const globalConfigPath = getGlobalConfigPath()
-  let configPath = options.global ? globalConfigPath : localConfigFileName
+export const configCommand = new Command('config')
+  .description('Configure global or local settings')
+  .option('-g, --global', 'Use global config')
+  .option('-p, --print', 'Print config')
+  .action(async (options) => {
+    const globalConfigPath = getGlobalConfigPath()
+    let configPath = options.global ? globalConfigPath : localConfigFileName
 
-  if (options.print) {
-    await printConfig(configPath)
-    return
-  }
-
-  const existingConfig = existsSync(configPath) ? loadConfigAtPath(configPath) : undefined
-
-  if (!existingConfig && !options.global) {
-    const isGlobal = await select({
-      message: 'No config file found. Do you want to create one?',
-      choices: [
-        {
-          name: `Create a global config at ${globalConfigPath}`,
-          value: true,
-        },
-        {
-          name: `Create a local config at ${configPath}`,
-          value: false,
-        },
-      ],
-    })
-    if (isGlobal) {
-      configPath = globalConfigPath
-    } else {
-      configPath = localConfigFileName
+    if (options.print) {
+      await printConfig(configPath)
+      return
     }
-  }
-  console.log(`Config file path: ${configPath}`)
 
-  let { provider, model, apiKey } = await configPrompt({ provider: existingConfig?.defaultProvider, model: existingConfig?.defaultModel })
+    const existingConfig = existsSync(configPath) ? loadConfigAtPath(configPath) : undefined
 
-  if (apiKey && configPath === localConfigFileName) {
-    const option = await select({
-      message: 'It is not recommended to store API keys in the local config file. How would you like to proceed?',
-      choices: [
-        {
-          name: 'Save API key in the local config file',
-          value: 1,
-        },
-        {
-          name: 'Save API key in the global config file',
-          value: 2,
-        },
-        {
-          name: 'Save API key to .env file',
-          value: 3,
-        },
-      ],
-    })
-
-    switch (option) {
-      case 1:
-        // do nothing
-        break
-      case 2: {
-        const globalConfig = loadConfigAtPath(globalConfigPath) ?? {}
-        set(globalConfig, ['providers', provider, 'apiKey'], apiKey)
-        mkdirSync(dirname(globalConfigPath), { recursive: true })
-        writeFileSync(globalConfigPath, stringify(globalConfig))
-        console.log(`API key saved to global config file: ${globalConfigPath}`)
-        apiKey = undefined
-        break
+    if (!existingConfig && !options.global) {
+      const isGlobal = await select({
+        message: 'No config file found. Do you want to create one?',
+        choices: [
+          {
+            name: `Create a global config at ${globalConfigPath}`,
+            value: true,
+          },
+          {
+            name: `Create a local config at ${configPath}`,
+            value: false,
+          },
+        ],
+      })
+      if (isGlobal) {
+        configPath = globalConfigPath
+      } else {
+        configPath = localConfigFileName
       }
-      case 3: {
-        let envFileContent: string
-        if (existsSync('.env')) {
-          envFileContent = readFileSync('.env', 'utf8')
-          envFileContent += `\n${provider.toUpperCase()}_API_KEY=${apiKey}`
-        } else {
-          envFileContent = `${provider.toUpperCase()}_API_KEY=${apiKey}`
+    }
+    console.log(`Config file path: ${configPath}`)
+
+    let { provider, model, apiKey } = await configPrompt({ provider: existingConfig?.defaultProvider, model: existingConfig?.defaultModel })
+
+    if (apiKey && configPath === localConfigFileName) {
+      const option = await select({
+        message: 'It is not recommended to store API keys in the local config file. How would you like to proceed?',
+        choices: [
+          {
+            name: 'Save API key in the local config file',
+            value: 1,
+          },
+          {
+            name: 'Save API key in the global config file',
+            value: 2,
+          },
+          {
+            name: 'Save API key to .env file',
+            value: 3,
+          },
+        ],
+      })
+
+      switch (option) {
+        case 1:
+          // do nothing
+          break
+        case 2: {
+          const globalConfig = loadConfigAtPath(globalConfigPath) ?? {}
+          set(globalConfig, ['providers', provider, 'apiKey'], apiKey)
+          mkdirSync(dirname(globalConfigPath), { recursive: true })
+          writeFileSync(globalConfigPath, stringify(globalConfig))
+          console.log(`API key saved to global config file: ${globalConfigPath}`)
+          apiKey = undefined
+          break
         }
-        writeFileSync('.env', envFileContent)
-        console.log('API key saved to .env file')
-        apiKey = undefined
-        break
+        case 3: {
+          let envFileContent: string
+          if (existsSync('.env')) {
+            envFileContent = readFileSync('.env', 'utf8')
+            envFileContent += `\n${provider.toUpperCase()}_API_KEY=${apiKey}`
+          } else {
+            envFileContent = `${provider.toUpperCase()}_API_KEY=${apiKey}`
+          }
+          writeFileSync('.env', envFileContent)
+          console.log('API key saved to .env file')
+          apiKey = undefined
+          break
+        }
       }
     }
-  }
 
-  const newConfig = {
-    ...existingConfig,
-    defaultProvider: provider,
-    defaultModel: model,
-  }
-  if (apiKey) {
-    set(newConfig, ['providers', provider, 'apiKey'], apiKey)
-  }
-  mkdirSync(dirname(configPath), { recursive: true })
-  writeFileSync(configPath, stringify(newConfig))
-  console.log(`Config file saved at: ${configPath}`)
-  return
-}
+    const newConfig = {
+      ...existingConfig,
+      defaultProvider: provider,
+      defaultModel: model,
+    }
+    if (apiKey) {
+      set(newConfig, ['providers', provider, 'apiKey'], apiKey)
+    }
+    mkdirSync(dirname(configPath), { recursive: true })
+    writeFileSync(configPath, stringify(newConfig))
+    console.log(`Config file saved at: ${configPath}`)
+  })

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,19 +12,14 @@ const program = new Command()
 
 program.name('polka').description('Polka Codes CLI').version(version)
 
+// Main command for executing tasks
+program.argument('[task]', 'The task to execute').action(runTask)
+
 // Chat command
 program.command('chat').description('Start an interactive chat session').action(runChat)
 
 // Config command
-program
-  .command('config')
-  .description('Configure global or local settings')
-  .option('-g, --global', 'Use global config')
-  .option('-p, --print', 'Print config')
-  .action(configCommand)
-
-// Main command for executing tasks
-program.argument('[task]', 'The task to execute').action(runTask)
+program.addCommand(configCommand)
 
 // Commit command
 program.addCommand(commitCommand)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,7 +10,7 @@ import { addSharedOptions } from './options'
 
 const program = new Command()
 
-program.name('polka').description('Polka Codes CLI').version(version)
+program.name('polka-codes').description('Polka Codes CLI').version(version)
 
 // Main command for executing tasks
 program.argument('[task]', 'The task to execute').action(runTask)


### PR DESCRIPTION
This PR refactors the config command to use the Commander library for improved structure. The changes include:
    
    - Moving the config command into a new `Command` instance.
    - Adding options for global and print configurations.
    - Updating the main program to add the config command as a subcommand.