### PR TITLE
Refactor Usage Meter and Add Budget Parameter for AI Service Control

### DIFF
--- a/example.polkacodes.yml
+++ b/example.polkacodes.yml
@@ -27,9 +27,9 @@ defaultProvider: "deepseek"
 # Default model to use when not specified for a provider
 defaultModel: "deepseek-chat"
 
-# Maximum number of iterations for AI operations
+# Maximum number of messages for AI operations
 # Helps prevent infinite loops and excessive API calls
-maxIterations: 50
+maxMessageCount: 50
 
 # Hook configurations for different agents
 # Hooks allow you to run specific commands at certain points in the agent's lifecycle

--- a/packages/cli/src/Runner.ts
+++ b/packages/cli/src/Runner.ts
@@ -46,6 +46,7 @@ export class Runner {
     const service = createService(options.provider, {
       apiKey: options.apiKey,
       model: options.model,
+      usageMeter: this.#usageMeter,
     })
 
     let rules = options.config.rules

--- a/packages/cli/src/Runner.ts
+++ b/packages/cli/src/Runner.ts
@@ -10,11 +10,13 @@ import {
   MultiAgent,
   type TaskEventCallback,
   type TaskInfo,
+  UsageMeter,
   analyzerAgentInfo,
   architectAgentInfo,
   coderAgentInfo,
   createService,
 } from '@polka-codes/core'
+
 import type { Config } from './config'
 import { type ProviderOptions, getProvider } from './provider'
 import { listFiles } from './utils/listFiles'
@@ -24,7 +26,7 @@ export type RunnerOptions = {
   model: string
   apiKey?: string
   config: Config
-  maxIterations: number
+  maxMessageCount: number
   interactive: boolean
   eventCallback: TaskEventCallback
 }
@@ -32,9 +34,14 @@ export type RunnerOptions = {
 export class Runner {
   readonly #options: RunnerOptions
   readonly #multiAgent: MultiAgent
+  readonly #usageMeter: UsageMeter
 
   constructor(options: RunnerOptions) {
     this.#options = options
+    this.#usageMeter = new UsageMeter({
+      maxCost: 1, // TODO: from options
+      maxMessageCount: options.maxMessageCount,
+    })
 
     const service = createService(options.provider, {
       apiKey: options.apiKey,
@@ -170,10 +177,10 @@ ${fileList.join('\n')}${limited ? '\n<files_truncated>true</files_truncated>' : 
   }
 
   get usage() {
-    return this.#multiAgent.usage
+    return this.#usageMeter.usage
   }
 
   printUsage() {
-    this.#multiAgent.printUsage()
+    this.#usageMeter.printUsage()
   }
 }

--- a/packages/cli/src/Runner.ts
+++ b/packages/cli/src/Runner.ts
@@ -27,6 +27,7 @@ export type RunnerOptions = {
   apiKey?: string
   config: Config
   maxMessageCount: number
+  budget: number
   interactive: boolean
   eventCallback: TaskEventCallback
 }
@@ -39,7 +40,7 @@ export class Runner {
   constructor(options: RunnerOptions) {
     this.#options = options
     this.#usageMeter = new UsageMeter({
-      maxCost: 1, // TODO: from options
+      maxCost: options.budget,
       maxMessageCount: options.maxMessageCount,
     })
 

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -9,7 +9,7 @@ import { configPrompt } from './config'
 
 export const runChat = async (_options: any, command: Command) => {
   const options = command.parent?.opts() ?? {}
-  const { config, providerConfig, maxIterations, verbose } = parseOptions(options)
+  const { config, providerConfig, maxMessageCount, verbose } = parseOptions(options)
 
   let { provider, model, apiKey } = providerConfig.getConfigForAgent('coder') ?? {}
 
@@ -32,7 +32,7 @@ export const runChat = async (_options: any, command: Command) => {
     model: model ?? defaultModels[provider],
     apiKey,
     config: config ?? {},
-    maxIterations,
+    maxMessageCount,
     interactive: true,
     eventCallback: printEvent(verbose),
   })
@@ -50,25 +50,21 @@ export const runChat = async (_options: any, command: Command) => {
         taskInfo = info
         exitReason = reason
       }
-      switch (exitReason) {
-        case 'MaxIterations':
-          console.log('Max iterations reached.')
+      switch (exitReason.type) {
+        case 'UsageExceeded':
+          console.log('Usage exceeded.')
           chat.close()
           // TODO: ask user if they want to continue
           break
         case 'WaitForUserInput':
           break
-        default: {
-          switch (exitReason.type) {
-            case ToolResponseType.Interrupted:
-              console.log('Interrupted.')
-              chat.close()
-              break
-            case ToolResponseType.Exit:
-              chat.close()
-              return undefined
-          }
-        }
+        case ToolResponseType.Interrupted:
+          console.log('Interrupted.')
+          chat.close()
+          break
+        case ToolResponseType.Exit:
+          chat.close()
+          return undefined
       }
     },
     onExit: async () => {

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -9,7 +9,7 @@ import { configPrompt } from './config'
 
 export const runChat = async (_options: any, command: Command) => {
   const options = command.parent?.opts() ?? {}
-  const { config, providerConfig, maxMessageCount, verbose } = parseOptions(options)
+  const { config, providerConfig, maxMessageCount, verbose, budget } = parseOptions(options)
 
   let { provider, model, apiKey } = providerConfig.getConfigForAgent('coder') ?? {}
 
@@ -33,6 +33,7 @@ export const runChat = async (_options: any, command: Command) => {
     apiKey,
     config: config ?? {},
     maxMessageCount,
+    budget,
     interactive: true,
     eventCallback: printEvent(verbose),
   })

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -72,7 +72,7 @@ export const runTask = async (taskArg: string, _options: any, command: Command) 
     }
   }
 
-  const { providerConfig, config, maxIterations, verbose } = parseOptions(options)
+  const { providerConfig, config, maxMessageCount, verbose } = parseOptions(options)
 
   let { provider, model, apiKey } = providerConfig.getConfigForAgent('coder') ?? {}
 
@@ -92,7 +92,7 @@ export const runTask = async (taskArg: string, _options: any, command: Command) 
     model: model ?? defaultModels[provider],
     apiKey,
     config: config ?? {},
-    maxIterations,
+    maxMessageCount,
     interactive: false,
     eventCallback: printEvent(verbose),
   })

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -72,7 +72,7 @@ export const runTask = async (taskArg: string, _options: any, command: Command) 
     }
   }
 
-  const { providerConfig, config, maxMessageCount, verbose } = parseOptions(options)
+  const { providerConfig, config, maxMessageCount, verbose, budget } = parseOptions(options)
 
   let { provider, model, apiKey } = providerConfig.getConfigForAgent('coder') ?? {}
 
@@ -93,6 +93,7 @@ export const runTask = async (taskArg: string, _options: any, command: Command) 
     apiKey,
     config: config ?? {},
     maxMessageCount,
+    budget,
     interactive: false,
     eventCallback: printEvent(verbose),
   })

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -41,6 +41,7 @@ export const configSchema = z
     defaultProvider: z.string().optional(),
     defaultModel: z.string().optional(),
     maxMessageCount: z.number().int().positive().optional(),
+    budget: z.number().int().positive().optional(),
     hooks: z
       .object({
         agents: z.record(agentNameOrDefault, z.object({ beforeCompletion: z.string().optional() })).optional(),

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -40,7 +40,7 @@ export const configSchema = z
       .optional(),
     defaultProvider: z.string().optional(),
     defaultModel: z.string().optional(),
-    maxIterations: z.number().int().positive().optional(),
+    maxMessageCount: z.number().int().positive().optional(),
     hooks: z
       .object({
         agents: z.record(agentNameOrDefault, z.object({ beforeCompletion: z.string().optional() })).optional(),

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -12,7 +12,7 @@ export interface CliOptions {
   apiProvider?: string
   model?: string
   apiKey?: string
-  maxIterations?: number
+  maxMessageCount?: number
   verbose?: number
 }
 
@@ -22,7 +22,7 @@ export function addSharedOptions(command: Command) {
     .option('--api-provider <provider>', 'API provider')
     .option('--model <model>', 'Model ID')
     .option('--api-key <key>', 'API key')
-    .option('--max-iterations <iterations>', 'Maximum number of iterations to run. Default to 30', Number.parseInt)
+    .option('--max-messages <iterations>', 'Maximum number of messages to send. Default to 30', Number.parseInt, 30)
     .option('-v --verbose', 'Enable verbose output. Use -v for level 1, -vv for level 2', (value, prev) => prev + 1, 0)
 }
 
@@ -104,7 +104,7 @@ export function parseOptions(options: CliOptions, cwd: string = process.cwd(), h
   })
 
   return {
-    maxIterations: options.maxIterations ?? 30,
+    maxMessageCount: options.maxMessageCount ?? config.maxMessageCount ?? 30,
     verbose: options.verbose ?? 0,
     config,
     providerConfig,

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -13,6 +13,7 @@ export interface CliOptions {
   model?: string
   apiKey?: string
   maxMessageCount?: number
+  budget?: number
   verbose?: number
 }
 
@@ -23,6 +24,7 @@ export function addSharedOptions(command: Command) {
     .option('--model <model>', 'Model ID')
     .option('--api-key <key>', 'API key')
     .option('--max-messages <iterations>', 'Maximum number of messages to send. Default to 30', Number.parseInt, 30)
+    .option('--budget <budget>', 'Budget for the AI service. Default to $1000', Number.parseInt, 1000)
     .option('-v --verbose', 'Enable verbose output. Use -v for level 1, -vv for level 2', (value, prev) => prev + 1, 0)
 }
 
@@ -105,6 +107,7 @@ export function parseOptions(options: CliOptions, cwd: string = process.cwd(), h
 
   return {
     maxMessageCount: options.maxMessageCount ?? config.maxMessageCount ?? 30,
+    budget: options.budget ?? Number(process.env.POLKA_BUDGET) ?? config.budget ?? 1000,
     verbose: options.verbose ?? 0,
     config,
     providerConfig,

--- a/packages/cli/src/utils/eventHandler.ts
+++ b/packages/cli/src/utils/eventHandler.ts
@@ -52,8 +52,8 @@ export const printEvent = (verbose: number) => (event: TaskEvent) => {
       console.log('Files:', event.files)
       console.log()
       break
-    case TaskEventKind.MaxIterationsReached:
-      console.log('Max iterations reached')
+    case TaskEventKind.UsageExceeded:
+      console.log('\n\n======= Usage Exceeded ========\n')
       break
     case TaskEventKind.EndTask:
       break

--- a/packages/core/src/AiService/AiServiceBase.ts
+++ b/packages/core/src/AiService/AiServiceBase.ts
@@ -24,6 +24,7 @@ export interface AiServiceOptions {
   model?: string
   apiKey?: string
   baseUrl?: string
+  usageMeter?: UsageMeter
 }
 
 export type MessageParam = Anthropic.Messages.MessageParam
@@ -37,7 +38,11 @@ export type ApiUsage = {
 }
 
 export abstract class AiServiceBase {
-  protected readonly usageMeter = new UsageMeter()
+  protected readonly usageMeter: UsageMeter
+
+  constructor(usageMeter?: UsageMeter) {
+    this.usageMeter = usageMeter ?? new UsageMeter()
+  }
 
   abstract get model(): { id: string; info: ModelInfo }
 

--- a/packages/core/src/AiService/AiServiceBase.ts
+++ b/packages/core/src/AiService/AiServiceBase.ts
@@ -38,7 +38,7 @@ export type ApiUsage = {
 }
 
 export abstract class AiServiceBase {
-  protected readonly usageMeter: UsageMeter
+  readonly usageMeter: UsageMeter
 
   constructor(usageMeter?: UsageMeter) {
     this.usageMeter = usageMeter ?? new UsageMeter()
@@ -49,6 +49,8 @@ export abstract class AiServiceBase {
   abstract sendImpl(systemPrompt: string, messages: MessageParam[]): ApiStream
 
   async *send(systemPrompt: string, messages: MessageParam[]): ApiStream {
+    this.usageMeter.incrementMessageCount()
+
     const stream = this.sendImpl(systemPrompt, messages)
 
     for await (const chunk of stream) {
@@ -62,6 +64,8 @@ export abstract class AiServiceBase {
   }
 
   async request(systemPrompt: string, messages: MessageParam[]) {
+    this.usageMeter.incrementMessageCount()
+
     const stream = this.sendImpl(systemPrompt, messages)
     const usage: ApiUsage = {
       inputTokens: 0,
@@ -99,12 +103,5 @@ export abstract class AiServiceBase {
       reasoning,
       usage,
     }
-  }
-
-  /**
-   * Get current usage statistics
-   */
-  get usage(): ApiUsage {
-    return this.usageMeter.usage
   }
 }

--- a/packages/core/src/AiService/AnthropicService.ts
+++ b/packages/core/src/AiService/AnthropicService.ts
@@ -13,7 +13,7 @@ export class AnthropicService extends AiServiceBase {
   readonly model: { id: AnthropicModelId; info: ModelInfo }
 
   constructor(options: AiServiceOptions) {
-    super()
+    super(options.usageMeter)
 
     this.#options = options
     this.#client = new Anthropic({

--- a/packages/core/src/AiService/DeepSeekService.ts
+++ b/packages/core/src/AiService/DeepSeekService.ts
@@ -12,7 +12,7 @@ export class DeepSeekService extends AiServiceBase {
   readonly model: { id: string; info: ModelInfo }
 
   constructor(options: AiServiceOptions) {
-    super()
+    super(options.usageMeter)
 
     this.#client = new OpenAI({
       baseURL: 'https://api.deepseek.com/v1',

--- a/packages/core/src/AiService/OllamaService.ts
+++ b/packages/core/src/AiService/OllamaService.ts
@@ -12,7 +12,7 @@ export class OllamaService extends AiServiceBase {
   readonly model: { id: string; info: ModelInfo }
 
   constructor(options: AiServiceOptions) {
-    super()
+    super(options.usageMeter)
 
     this.#client = new OpenAI({
       baseURL: `${options.baseUrl || 'http://localhost:11434'}/v1`,

--- a/packages/core/src/AiService/OpenRouterService.ts
+++ b/packages/core/src/AiService/OpenRouterService.ts
@@ -13,7 +13,7 @@ export class OpenRouterService extends AiServiceBase {
   readonly model: { id: string; info: ModelInfo }
 
   constructor(options: AiServiceOptions) {
-    super()
+    super(options.usageMeter)
 
     if (!options.model) {
       throw new Error('OpenRouter requires a model')

--- a/packages/core/src/AiService/UsageMeter.ts
+++ b/packages/core/src/AiService/UsageMeter.ts
@@ -22,8 +22,8 @@ export class UsageMeter {
 
   constructor(options: { maxCost?: number; maxMessageCount?: number } = {}) {
     // default to some something is definitely wrong if ever exceeded value
-    this.maxCost = options.maxCost ?? 1000
-    this.maxMessageCount = options.maxMessageCount ?? 1000
+    this.maxCost = options.maxCost || 1000
+    this.maxMessageCount = options.maxMessageCount || 1000
   }
 
   /**

--- a/packages/core/src/AiService/UsageMeter.ts
+++ b/packages/core/src/AiService/UsageMeter.ts
@@ -7,12 +7,23 @@ import type { ApiUsage } from './AiServiceBase'
 import type { ModelInfo } from './ModelInfo'
 
 export class UsageMeter {
-  #usage: ApiUsage = {
+  #usage = {
     inputTokens: 0,
     outputTokens: 0,
     cacheWriteTokens: 0,
     cacheReadTokens: 0,
     totalCost: 0,
+  }
+
+  #messageCount = 0
+
+  readonly maxCost: number
+  readonly maxMessageCount: number
+
+  constructor(options: { maxCost?: number; maxMessageCount?: number } = {}) {
+    // default to some something is definitely wrong if ever exceeded value
+    this.maxCost = options.maxCost ?? 1000
+    this.maxMessageCount = options.maxMessageCount ?? 1000
   }
 
   /**
@@ -34,7 +45,21 @@ export class UsageMeter {
         1_000_000
     }
 
-    this.#usage.totalCost = (this.#usage.totalCost ?? 0) + (usage.totalCost ?? 0)
+    this.#usage.totalCost += usage.totalCost ?? 0
+  }
+
+  incrementMessageCount(count = 1) {
+    this.#messageCount += count
+  }
+
+  isLimitExceeded() {
+    const messageCount = this.#messageCount >= this.maxMessageCount
+    const cost = this.#usage.totalCost >= this.maxCost
+    return {
+      messageCount,
+      cost,
+      result: messageCount || cost,
+    }
   }
 
   /**

--- a/packages/core/src/AiService/index.ts
+++ b/packages/core/src/AiService/index.ts
@@ -4,6 +4,7 @@ import { DeepSeekService } from './DeepSeekService'
 import type { ModelInfo } from './ModelInfo'
 import { OllamaService } from './OllamaService'
 import { OpenRouterService } from './OpenRouterService'
+import { UsageMeter } from './UsageMeter'
 
 export enum AiServiceProvider {
   Anthropic = 'anthropic',
@@ -32,5 +33,7 @@ export const createService = (provider: AiServiceProvider, options: AiServiceOpt
       return new OpenRouterService(options)
   }
 }
+
+export { UsageMeter }
 
 export type { MessageParam, AiServiceOptions, AiServiceBase, ModelInfo, ApiUsage }

--- a/packages/core/src/AiTool/index.ts
+++ b/packages/core/src/AiTool/index.ts
@@ -25,7 +25,7 @@ export const executeAgentTool = async <T extends AiToolDefinition<any, any>>(
   agent: MultiAgent,
   params: GetInput<T>,
   callback?: TaskEventCallback,
-): Promise<{ response: GetOutput<T>; usage: ApiUsage }> => {
+): Promise<GetOutput<T>> => {
   if (!definition.agent) {
     throw new Error('Agent not specified')
   }
@@ -38,15 +38,11 @@ export const executeAgentTool = async <T extends AiToolDefinition<any, any>>(
   })
 
   // Check if we have a successful completion
-  const isSuccess = typeof exitReason === 'object' && 'type' in exitReason && exitReason.type === ToolResponseType.Exit
-  if (isSuccess) {
-    return {
-      response: definition.parseOutput(exitReason.message),
-      usage: agent.usage,
-    }
+  if (exitReason.type === ToolResponseType.Exit) {
+    return definition.parseOutput(exitReason.message)
   }
 
-  throw new Error(`Tool execution failed: ${JSON.stringify(exitReason)}`)
+  throw new Error(`Tool execution failed: ${exitReason.type}`)
 }
 
 export const makeTool = <T extends AiToolDefinition<any, any>>(definition: T) => {


### PR DESCRIPTION
This PR introduces a new `UsageMeter` class to track API usage metrics, including input, output, cache read, and write tokens, as well as total cost. It also adds a `budget` parameter to the `Runner` class for better cost tracking and resource management.

    **Summary of Changes**:
    - Added `UsageMeter` class in `packages/core/src/AiService/UsageMeter.ts`.
    - Updated `AiServiceBase` to use the `UsageMeter` instance.
    - Modified `Runner`, `chat`, and `task` commands to include the `budget` parameter.
    - Refactored `maxIterations` to `maxMessageCount` in configuration files.

    **Highlights of Changed Code**:
    - Added `UsageMeter` class with methods for adding usage, incrementing message count, and checking if limits are exceeded.
    - Updated `AiServiceBase` to use the `UsageMeter`.
    - Modified `Runner`, `chat`, and `task` commands to include the `budget` parameter.
    - Refactored `maxIterations` to `maxMessageCount` in configuration files.

    **Additional Information (if needed)**:
    - Testing steps: Run existing tests and ensure that new functionality works as expected.
    - Notes or caveats: Ensure that the budget calculation is accurate based on the usage metrics provided by each AI service provider.