### PR TITLE
Prevent Multiple Tool Executions in Handover and Delegate Scenarios

### DIFF
--- a/packages/core/src/Agent/AgentBase.ts
+++ b/packages/core/src/Agent/AgentBase.ts
@@ -323,6 +323,11 @@ export abstract class AgentBase {
               await this.#callback({ kind: TaskEventKind.ToolInterrupted, agent: this, tool: content.name })
               return { exit: toolResp }
             case ToolResponseType.HandOver:
+              if (toolReponses.length > 0) {
+                // agent is trying run multiple tools at the same time
+                // ignore the request in this case
+                continue
+              }
               // hand over the task to another agent
               await this.#callback({
                 kind: TaskEventKind.ToolHandOver,
@@ -335,6 +340,11 @@ export abstract class AgentBase {
               })
               return { exit: toolResp }
             case ToolResponseType.Delegate:
+              if (toolReponses.length > 0) {
+                // agent is trying run multiple tools at the same time
+                // ignore the request in this case
+                continue
+              }
               // delegate the task to another agent
               await this.#callback({
                 kind: TaskEventKind.ToolDelegate,


### PR DESCRIPTION
**Summary of Changes**:
- Added checks to prevent multiple tool executions during handover and delegate scenarios in the `AgentBase` class.

**Highlights of Changed Code**:
- Introduced conditional checks in the `#handleResponse` method to ignore handover and delegate requests if other tools are already being executed.

**Additional Information (if needed)**:
- This change ensures that only one tool is executed at a time during handover and delegate operations, preventing potential conflicts or unexpected behavior.