### PR TITLE
Add Support for Tool Pause Functionality

### DIFF
--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -42,6 +42,7 @@ export enum ToolResponseType {
   Interrupted = 'Interrupted',
   HandOver = 'HandOver',
   Delegate = 'Delegate',
+  Pause = 'Pause',
 }
 
 // Reply to the tool use
@@ -104,6 +105,11 @@ export type ToolResponseDelegate = {
   originalTask?: string
 }
 
+export type ToolResponsePause = {
+  type: ToolResponseType.Pause
+  object: any
+}
+
 export type ToolResponse =
   | ToolResponseReply
   | ToolResponseExit
@@ -112,6 +118,7 @@ export type ToolResponse =
   | ToolResponseInterrupted
   | ToolResponseHandOver
   | ToolResponseDelegate
+  | ToolResponsePause
 
 export type ToolHandler<T extends ToolInfo, P> = (
   provider: P,


### PR DESCRIPTION
This PR adds support for tool pause functionality in AgentBase and updates ToolResponseType enum.

**Summary of Changes**:
- Added a new `ToolPause` event to the `TaskEventKind` enum.
- Introduced a new `TaskEventToolPause` interface to handle tool pause events.
- Updated the `ToolResponseType` enum to include a `Pause` type.
- Modified the `#handleResponse` method in `AgentBase` to handle the new `ToolResponseType.Pause` case.

**Highlights of Changed Code**:
- The `TaskEventKind` enum now includes `ToolPause`.
- A new `TaskEventToolPause` interface is defined.
- The `ToolResponseType` enum has been updated with a `Pause` type.
- The `#handleResponse` method in `AgentBase` now handles `ToolResponseType.Pause`.

