### PR TITLE
feat: Enhance tool parameter parsing for arrays and nesting

### DIFF
--- a/packages/core/src/Agent/CoderAgent/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/Agent/CoderAgent/__snapshots__/prompts.test.ts.snap
@@ -69,7 +69,7 @@ Parameters:
 
 Usage:
 <tool_ask_followup_question>
-<tool_parameter_questions>undefined</tool_parameter_questions>
+<tool_parameter_questions>questions here</tool_parameter_questions>
 </tool_ask_followup_question>
 
 ## tool_attempt_completion

--- a/packages/core/src/Agent/CoderAgent/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/Agent/CoderAgent/__snapshots__/prompts.test.ts.snap
@@ -65,10 +65,11 @@ NEVER surround tool use with triple backticks (\`\`\`).
 Description: Call this when vital details are missing. Pose each follow-up as one direct, unambiguous question. If it speeds the reply, add up to five short, mutually-exclusive answer options. Group any related questions in the same call to avoid a back-and-forth chain.
 
 Parameters:
-- tool_parameter_questions: (required) One or more follow-up questions you need answered before you can continue.
+- tool_parameter_questions: (required) (multiple allowed) One or more follow-up questions you need answered before you can continue.
 
 Usage:
 <tool_ask_followup_question>
+<tool_parameter_questions>questions here</tool_parameter_questions>
 <tool_parameter_questions>questions here</tool_parameter_questions>
 </tool_ask_followup_question>
 

--- a/packages/core/src/Agent/knowledge.ai.yml
+++ b/packages/core/src/Agent/knowledge.ai.yml
@@ -13,8 +13,8 @@ files:
   MultiAgent.ts:
     description: Multi-agent coordination
   parseAssistantMessage.ts:
-    description: Parses assistant messages to extract text content and tool use with
-      parameters, supporting array mode and nested objects
+    description: Parses assistant messages to extract tool usage and parameters,
+      with improved support for array parameters with nested objects
     api:
       interfaces:
         "1":
@@ -26,6 +26,7 @@ files:
             "2":
               name: content
               type: string
+          description: Represents plain text content in an assistant message
         "2":
           name: ToolUse
           properties:
@@ -38,21 +39,29 @@ files:
             "3":
               name: params
               type: Record<string, any>
+          description: Represents a tool use in an assistant message
+        "3":
+          name: AssistantMessageContent
+          description: Union type of TextContent and ToolUse
       functions:
         "1":
           name: parseAssistantMessage
-          description: Parses an assistant's message into an array of text content and
-            tool use content, supporting array mode and nested objects
+          description: Parses an assistant's message into text content and tool use
+            content, with improved support for array parameters with nested
+            objects
           params:
             "1":
               name: assistantMessage
               type: string
+              description: The message to parse
             "2":
               name: tools
               type: ToolInfo[]
+              description: Available tools
             "3":
               name: toolNamePrefix
               type: string
+              description: Prefix for tool names in XML tags
           returns: AssistantMessageContent[]
   policies/KnowledgeManagement.ts:
     description: Knowledge management policy
@@ -117,6 +126,7 @@ files:
               type: "Record<string, string | { command: string; description: string }>"
           returns: string
 rules:
-  "1": Each agent should implement a clear responsibility
-  "2": Follow consistent prompt engineering patterns
-  "3": Maintain separation of concerns between agents
+  "1": Tool parameters can be arrays if allowMultiple is true
+  "2": Tool parameters can have nested structure if children is defined
+  "3": When parsing nested parameters, respect the children definition
+  "4": When parsing array parameters, respect the allowMultiple flag

--- a/packages/core/src/Agent/prompts.ts
+++ b/packages/core/src/Agent/prompts.ts
@@ -21,11 +21,23 @@ const toolInfoPrompt = (tool: ToolInfo, toolNamePrefix: string, parameterPrefix:
 Description: ${tool.description}
 
 Parameters:
-${tool.parameters.map((param) => `- ${parameterPrefix}${param.name}: (${param.required ? 'required' : 'optional'}) ${param.description}`).join('\n')}
+${tool.parameters
+  .map(
+    (param) =>
+      `- ${parameterPrefix}${param.name}: (${param.required ? 'required' : 'optional'})${param.allowMultiple ? ' (multiple allowed)' : ''} ${param.description}`,
+  )
+  .join('\n')}
 
 Usage:
 <${toolNamePrefix}${tool.name}>
-${tool.parameters.map((param) => `<${parameterPrefix}${param.name}>${param.usageValue}</${parameterPrefix}${param.name}>`).join('\n')}
+${tool.parameters
+  .map((param) =>
+    param.allowMultiple
+      ? `<${parameterPrefix}${param.name}>${param.usageValue}</${parameterPrefix}${param.name}>
+<${parameterPrefix}${param.name}>${param.usageValue}</${parameterPrefix}${param.name}>`
+      : `<${parameterPrefix}${param.name}>${param.usageValue}</${parameterPrefix}${param.name}>`,
+  )
+  .join('\n')}
 </${toolNamePrefix}${tool.name}>`
 
 const toolInfoExamplesPrompt = (tool: ToolInfo, example: ToolExample, toolNamePrefix: string, parameterPrefix: string) => `

--- a/packages/core/src/tools/askFollowupQuestion.ts
+++ b/packages/core/src/tools/askFollowupQuestion.ts
@@ -12,6 +12,7 @@ export const toolInfo = {
       description: 'One or more follow-up questions you need answered before you can continue.',
       required: true,
       allowMultiple: true,
+      usageValue: 'questions here',
       children: [
         {
           name: 'prompt',


### PR DESCRIPTION
**Summary of Changes**:
- Updated the `parseAssistantMessage` function to correctly parse tool parameters defined as arrays (using `allowMultiple: true`) or nested objects (using the `children` property in `ToolParameter`).
- Added support for parsing arrays of nested objects within tool parameters.
- Modified the `toolUsePrompt` generation in `prompts.ts` to accurately reflect array and nested capabilities in parameter descriptions and usage examples.
- Updated descriptions and added parsing rules in `knowledge.ai.yml`.
- Added and significantly updated unit tests in `parseAssistantMessage.test.ts` to cover various new parsing scenarios, including edge cases.
- Updated test snapshots in `prompts.test.ts.snap`.

**Highlights of Changed Code**:
- `parseAssistantMessage.ts`: Reworked parsing logic to check `allowMultiple` and `children` properties from `ToolInfo` before processing parameters as arrays or nested structures. Enhanced the `parseNestedParameters` helper function.
- `parseAssistantMessage.test.ts`: Introduced new mock tool definitions with `allowMultiple` and `children`. Added tests specifically for array parameters, nested parameters, arrays of nested objects, and handling cases where parameters incorrectly use array/nested syntax but the tool definition doesn't support it.
- `prompts.ts`: Updated `toolInfoPrompt` to display `(multiple allowed)` for array parameters and generate appropriate multi-tag examples.
- `knowledge.ai.yml`: Revised descriptions for `parseAssistantMessage` and `toolUsePrompt`; added new rules regarding array/nested parsing.

**Additional Information (if needed)**:
- N/A