### PR TITLE
Add OpenRouter Referer and Title Headers in getModel Configuration

### DIFF
--- a/packages/cli/src/getModel.ts
+++ b/packages/cli/src/getModel.ts
@@ -216,6 +216,10 @@ export const getModel = (config: ModelConfig, debugLogging = false): LanguageMod
         apiKey: config.apiKey,
         baseURL: config.baseUrl,
         fetch: fetchOverride,
+        headers: {
+          'HTTP-Referer': 'https://polka.codes',
+          'X-Title': 'Polka Codes',
+        },
       })
       return openrouter.chat(config.model, {
         usage: { include: true },


### PR DESCRIPTION
**Summary of Changes**:
- Added custom headers for OpenRouter requests: HTTP-Referer and X-Title.
- Ensures requests identify the originating site and application name.

**Highlights of Changed Code**:
- packages/cli/src/getModel.ts: In AiProvider.OpenRouter case, passed headers { 'HTTP-Referer': 'https://polka.codes', 'X-Title': 'Polka Codes' } to createOpenRouter configuration.

**Additional Information**:
- No breaking changes expected.
- Verify OpenRouter analytics/attribution reflects the new headers.