### PR TITLE
refactor(workflow): improve tool invocation API

### DIFF
--- a/packages/cli/src/workflows/pr.workflow.ts
+++ b/packages/cli/src/workflows/pr.workflow.ts
@@ -32,7 +32,7 @@ Example format:
 export const prWorkflow: Workflow<{ context?: string }, { title: string; description: string }, PRWorkflowTools> = {
   name: 'Create Pull Request',
   description: 'Generate a pull request title and description and create the pull request.',
-  async *fn(input, step, useTool) {
+  async *fn(input, step, tools) {
     const { diff, commits, branchName } = await step('get-git-info', async () => {
       checkGhInstalled()
       const branchName = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim()
@@ -56,7 +56,7 @@ export const prWorkflow: Workflow<{ context?: string }, { title: string; descrip
       messageParts.push(`<user_context>${input.context}</user_context>`)
     }
 
-    const prDetails = yield* useTool('invokeAgent', {
+    const prDetails = yield* tools.invokeAgent({
       agent: 'analyzer',
       messages: [
         GET_PR_DETAILS_PROMPT,
@@ -68,7 +68,7 @@ export const prWorkflow: Workflow<{ context?: string }, { title: string; descrip
       outputSchema: prDetailsSchema,
     })
 
-    const result = yield* useTool('createPullRequest', prDetails as { title: string; description: string })
+    const result = yield* tools.createPullRequest(prDetails as { title: string; description: string })
 
     return result
   },

--- a/packages/workflow/src/tool-adapter.integration.test.ts
+++ b/packages/workflow/src/tool-adapter.integration.test.ts
@@ -25,8 +25,8 @@ describe('tool-adapter integration', () => {
     const testWorkflow: Workflow<{ path: string[] }, string, TestTools> = {
       name: 'test',
       description: 'test workflow',
-      async *fn(input, _step, useTool) {
-        const fileContent = yield* useTool('readFile', { path: input.path, includeIgnored: undefined })
+      async *fn(input, _step, tools) {
+        const fileContent = yield* tools.readFile({ path: input.path, includeIgnored: undefined })
         if (fileContent.type !== ToolResponseType.Reply) {
           throw new Error('unexpected tool response')
         }

--- a/packages/workflow/src/workflow.test.ts
+++ b/packages/workflow/src/workflow.test.ts
@@ -20,8 +20,8 @@ const simpleWorkflow: Workflow<string, string, Tools> = {
 const singleToolWorkflow: Workflow<number, number, Tools> = {
   name: 'singleTool',
   description: 'A workflow with a single tool',
-  async *fn(input, _step, useTool) {
-    const result = yield* useTool('add', { a: input, b: 2 })
+  async *fn(input, _step, tools) {
+    const result = yield* tools.add({ a: input, b: 2 })
     return result
   },
 }
@@ -29,9 +29,9 @@ const singleToolWorkflow: Workflow<number, number, Tools> = {
 const multiToolWorkflow: Workflow<string, string, Tools> = {
   name: 'multiTool',
   description: 'A workflow with multiple tools',
-  async *fn(input, _step, useTool) {
-    const r1 = yield* useTool('concat', { a: 'hello', b: ' ' })
-    const r2 = yield* useTool('concat', { a: r1, b: input })
+  async *fn(input, _step, tools) {
+    const r1 = yield* tools.concat({ a: 'hello', b: ' ' })
+    const r2 = yield* tools.concat({ a: r1, b: input })
     return r2
   },
 }
@@ -48,8 +48,8 @@ const failingWorkflow: Workflow<null, null, Tools> = {
 const failingAfterToolWorkflow: Workflow<number, number, Tools> = {
   name: 'failingAfterTool',
   description: 'A workflow that fails after a tool call',
-  async *fn(input, _step, useTool) {
-    yield* useTool('add', { a: input, b: 2 })
+  async *fn(input, _step, tools) {
+    yield* tools.add({ a: input, b: 2 })
     throw new Error('failed after tool')
   },
 }


### PR DESCRIPTION
This pull request refactors the tool invocation API within workflows to provide a more intuitive and type-safe developer experience.

### Changes

The previous `useTool` function has been replaced with a `tools` object, allowing for a more direct and readable tool invocation syntax.

**Before:**
```typescript
const result = yield* useTool('add', { a: input, b: 2 })
```

**After:**
```typescript
const result = yield* tools.add({ a: input, b: 2 })
```

This was achieved by:
- Updating the `WorkflowFn` signature to pass a `tools` object.
- Using a `Proxy` in the core `run` function to dynamically handle calls to different tools, making the API more ergonomic.
- Updating all existing workflow definitions and tests to adopt the new API.