### PR TITLE
feat(cli): add interactive plan command

### DIFF
--- a/packages/cli/src/commands/plan.ts
+++ b/packages/cli/src/commands/plan.ts
@@ -1,0 +1,30 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { input } from '@inquirer/prompts'
+import { Command } from 'commander'
+import { runWorkflow } from '../runWorkflow'
+import { planWorkflow } from '../workflows/plan.workflow'
+
+export const planCommand = new Command('plan')
+  .description('Create or update a plan for a task.')
+  .argument('[task]', 'The task to plan.')
+  .option('-f, --file <path>', 'The path to the plan file.')
+  .action(async (task: string | undefined, options: { file?: string }, command: Command) => {
+    let taskInput = task
+    if (!taskInput) {
+      try {
+        taskInput = await input({ message: 'What is the task you want to plan?' })
+      } catch (error) {
+        if (error instanceof Error && error.name === 'ExitPromptError') {
+          return
+        }
+        throw error
+      }
+    }
+
+    let fileContent: string | undefined
+    if (options.file && existsSync(options.file)) {
+      fileContent = readFileSync(options.file, 'utf-8')
+    }
+
+    await runWorkflow('plan', planWorkflow, command, { task: taskInput, fileContent, filePath: options.file })
+  })

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,7 @@ import { runChat } from './commands/chat'
 import { commitCommand } from './commands/commit'
 import { createCommand } from './commands/create'
 import { initCommand } from './commands/init'
+import { planCommand } from './commands/plan'
 import { prCommand } from './commands/pr'
 import { reviewCommand } from './commands/review'
 import { runTask } from './commands/task'
@@ -37,6 +38,9 @@ program.addCommand(reviewCommand)
 
 // Create command
 program.addCommand(createCommand)
+
+// Plan command
+program.addCommand(planCommand)
 
 addSharedOptions(program)
 

--- a/packages/cli/src/prices.ts
+++ b/packages/cli/src/prices.ts
@@ -11,7 +11,6 @@ export type ModelInfo = {
 export default {
   [AiProvider.Anthropic]: {
     'claude-sonnet-4-5-20250929': { inputPrice: 3, outputPrice: 15, cacheWritesPrice: 3.75, cacheReadsPrice: 0.3, supportsThinking: true },
-
     'claude-opus-4-20250514': { inputPrice: 15, outputPrice: 75, cacheWritesPrice: 18.75, cacheReadsPrice: 1.5, supportsThinking: true },
     'claude-opus-4-1-20250805': { inputPrice: 15, outputPrice: 75, cacheWritesPrice: 18.75, cacheReadsPrice: 1.5, supportsThinking: true },
     'claude-sonnet-4-20250514': { inputPrice: 3, outputPrice: 15, cacheWritesPrice: 3.75, cacheReadsPrice: 0.3, supportsThinking: true },
@@ -23,7 +22,6 @@ export default {
   [AiProvider.Ollama]: {},
 
   [AiProvider.DeepSeek]: {
-    // Prices reflect V3.2-Exp; same endpoints
     'deepseek-chat': { inputPrice: 0.28, outputPrice: 0.42, cacheWritesPrice: 0, cacheReadsPrice: 0.028 },
     'deepseek-reasoner': { inputPrice: 0.28, outputPrice: 0.42, cacheWritesPrice: 0, cacheReadsPrice: 0.028, supportsThinking: true },
   },

--- a/packages/cli/src/workflow-tools.ts
+++ b/packages/cli/src/workflow-tools.ts
@@ -9,4 +9,6 @@ export type WorkflowTools = {
   createCommit: ToolSignature<{ message: string }, { message: string }>
   printChangeFile: ToolSignature<Record<string, never>, { stagedFiles: FileChange[]; unstagedFiles: FileChange[] }>
   confirm: ToolSignature<{ message: string; default: false }, boolean>
+  input: ToolSignature<{ message: string; default?: string }, string>
+  writeToFile: ToolSignature<{ path: string; content: string }, Record<string, never>>
 }

--- a/packages/cli/src/workflows/index.ts
+++ b/packages/cli/src/workflows/index.ts
@@ -2,6 +2,7 @@
 
 export * from './commit.workflow'
 export * from './init.workflow'
+export * from './plan.workflow'
 export * from './pr.workflow'
 export * from './review.workflow'
 export * from './workflow.utils'

--- a/packages/cli/src/workflows/plan.workflow.ts
+++ b/packages/cli/src/workflows/plan.workflow.ts
@@ -1,0 +1,108 @@
+import type { Workflow } from '@polka-codes/workflow'
+import { z } from 'zod'
+import type { WorkflowTools } from '../workflow-tools'
+
+export type PlanWorkflowInput = {
+  task: string
+  fileContent?: string
+  filePath?: string
+}
+
+const PlanSchema = z.object({
+  plan: z.string().optional(),
+  ready: z.boolean(),
+  question: z.string().optional(),
+})
+
+const PLAN_PROMPT = `
+You are an expert planner. Your goal is to create a detailed plan for a given task.
+
+The user has provided a task:
+<task>
+{task}
+</task>
+
+And optionally, the content of an existing plan file:
+<plan_file>
+{fileContent}
+</plan_file>
+
+Your tasks are:
+1.  Analyze the task and the existing plan (if any).
+2.  If the requirements are clear and you can generate or update the plan, set "ready" to true and provide the plan in the "plan" field.
+3.  If the requirements are not clear, set "ready" to false and ask a clarifying question in the "question" field.
+
+Respond with a JSON object that matches the following schema:
+{
+  "plan": "The generated or updated plan.",
+  "ready": true,
+  "question": "The clarifying question to ask the user."
+}
+`
+
+import type { PlainJson } from '@polka-codes/workflow'
+
+export const planWorkflow: Workflow<PlanWorkflowInput, PlainJson, WorkflowTools> = {
+  name: 'Plan Task',
+  description: 'Create or update a plan for a given task.',
+  async *fn(input, _step, tools) {
+    const { task, fileContent, filePath } = input
+    let plan = fileContent || ''
+    let isPlanReady = false
+    let userFeedback = ''
+
+    while (true) {
+      const currentTask = userFeedback ? `${task}\n\nUser feedback: ${userFeedback}` : task
+      const prompt = PLAN_PROMPT.replace('{task}', currentTask).replace('{fileContent}', plan)
+      const {
+        plan: newPlan,
+        ready,
+        question,
+      } = yield* tools.invokeAgent({
+        agent: 'architect',
+        messages: [{ type: 'user', content: prompt }],
+        outputSchema: PlanSchema,
+      })
+
+      if (newPlan !== undefined) {
+        plan = newPlan
+      }
+      isPlanReady = ready
+
+      if (!isPlanReady && question) {
+        const answer = yield* tools.input({ message: question })
+        userFeedback = `Question: ${question}\nAnswer: ${answer}`
+        continue // Loop back to the agent with the user's answer
+      }
+
+      console.log('\nGenerated Plan:\n')
+      console.log(plan)
+
+      try {
+        userFeedback = yield* tools.input({
+          message: 'What changes do you want to make? (leave empty or press Ctrl+C to exit)',
+        })
+      } catch (_error) {
+        // ExitPromptError is thrown on Ctrl+C
+        userFeedback = ''
+      }
+
+      if (!userFeedback) {
+        break // Exit the loop if the user provides no feedback
+      }
+    }
+
+    const savePlan = yield* tools.confirm({ message: 'Do you want to save the plan?', default: false })
+
+    if (savePlan) {
+      let savePath = filePath
+      if (!savePath) {
+        savePath = yield* tools.input({ message: 'Where do you want to save the plan?', default: 'docs/plan.md' })
+      }
+      yield* tools.writeToFile({ path: savePath, content: plan })
+      console.log(`Plan saved to ${savePath}`)
+    }
+
+    return {}
+  },
+}


### PR DESCRIPTION
This pull request introduces a new interactive `plan` command to the CLI. This command helps users create a detailed plan for a given task by leveraging an AI agent and allowing for iterative feedback.

### How it Works

1.  Run the command with a task: `bun cli plan "Implement a new feature"`.
2.  If the task is unclear, the agent will ask clarifying questions.
3.  An initial plan is generated and displayed.
4.  The user is prompted for feedback or changes. This loop continues until the user is satisfied.
5.  The final plan can be saved to a file (e.g., `docs/plan.md`).

You can also update an existing plan using the `--file` option.

### Key Changes

- **`plan` command**: Added a new `plan` command to `packages/cli/src/commands/plan.ts`.
- **`plan.workflow.ts`**: Created a new workflow to manage the interactive planning process.
- **Interactive Loop**: The workflow iteratively interacts with the user to refine the plan.
- **New Workflow Tools**: Added `input` and `writeToFile` tools to `workflow-tools.ts` to support user interaction and file saving.