### PR TITLE
[codex] Improve README documentation structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,26 +10,21 @@
 > **Note**
 > This project is under active development. APIs and features may evolve, but we strive to maintain backward compatibility when possible.
 
-Polka Codes is a powerful TypeScript-based AI coding assistant framework that helps developers with task planning, code generation, and more. It uses natural language interactions, a multi-agent system, a command-line interface, and seamless GitHub integration to streamline your development workflow.
+Polka Codes is a TypeScript-based AI coding assistant framework for planning work, generating code, fixing failures, reviewing changes, and automating common repository workflows. It combines a command-line interface, multi-agent workflows, GitHub integration, and configurable project automation.
 
-## ✨ Features
+## Features
 
-- 📝 **Task Planning**: Create detailed implementation plans for your tasks using the `plan` command
-- 💻 **Code Generation**: Implement features from a plan or a simple description with the `code` command
-- 🐛 **Automated Debugging**: Automatically fix failing tests or commands with the `fix` command
-- 🔍 **Code Review**: Get AI-powered feedback on your pull requests and local changes with automatic fix application
-- 🤖 **AI-Assisted Git Workflow**: Generate commit messages and create pull requests with the `commit` and `pr` commands
-- 💾 **Checkpoint & Resume**: Save and restore work state with the `checkpoints` and `continue` commands
-- 🎯 **Custom Scripts**: Define and execute custom TypeScript scripts and shell commands with the `run` and `init` commands
-- 🤝 **Multi-Agent System**: Specialized AI agents (Architect, Coder, etc.) collaborate on complex tasks
-- 🔧 **Simple Setup**: Quickly initialize your project configuration with `init`
-- 🔄 **GitHub Integration**: GitHub Actions integration for PR/issue mentions
-- 📦 **Extensible Architecture**: Modular design for adding AI providers, tools, and agents
-- ⚡ **Type Safety**: Fully typed with TypeScript for better DX
-- 🧪 **Thoroughly Tested**: 800+ tests using `bun:test` with snapshot testing
-- 🤖 **Multiple AI Providers**: Anthropic Claude, Google Vertex, DeepSeek, OpenAI, OpenRouter, Ollama
-- 🔌 **MCP Support**: Consume tools from external MCP servers and expose workflows via MCP server
-- 🚀 **Auto-Fix**: Automatically detect and fix lint/type errors after code changes
+- **Task planning**: create implementation plans with `plan`.
+- **Code generation**: implement features from a plan or prompt with `code`.
+- **Automated fixing**: run failing commands and let agents repair issues with `fix`.
+- **Code review**: review local changes, commit ranges, or GitHub pull requests with `review`.
+- **Git workflow support**: generate commit messages and pull requests with `commit` and `pr`.
+- **Checkpoint and resume**: inspect and continue saved agent state with `checkpoints` and `continue`.
+- **Custom scripts**: define project scripts in `.polkacodes.yml` and run them with `run`.
+- **Skills and autonomous agents**: manage reusable skills with `skills` and run experimental continuous-improvement agents with `agent`.
+- **Custom workflows**: execute workflow files with `workflow`.
+- **MCP support**: consume tools from external MCP servers and expose Polka workflows with `mcp-server`.
+- **Multiple AI providers**: configure providers such as DeepSeek, Anthropic, OpenAI, OpenRouter, Google Vertex, and Ollama.
 
 ## Quick Start
 
@@ -45,16 +40,14 @@ npx @polka-codes/cli "your task description"
 
 ### Example Workflow
 
-Here's an example of a typical development workflow using Polka Codes:
-
 ```bash
-# 1. Create a detailed implementation plan for a task
+# 1. Create a detailed implementation plan
 polka plan --plan-file auth.plan.md "Implement JWT-based auth"
 
-# 2. Implement the feature based on the plan
+# 2. Implement the plan
 polka code --file auth.plan.md
 
-# 3. Fix any issues that arise (e.g., failing tests)
+# 3. Fix any issues that arise
 polka fix "bun test"
 
 # 4. Commit your changes with an AI-generated message
@@ -64,372 +57,88 @@ polka commit -a
 polka pr
 ```
 
-## Code Review
+## Documentation
 
-The `review` command provides AI-powered code reviews for your projects. It can be used to review GitHub pull requests or local changes. The command can also attempt to automatically fix the issues it finds. Use the `--loop` option to have it re-review its own changes until the review is clean or the loop limit is reached.
+- [CLI README](packages/cli/README.md): command reference, installation details, configuration, environment variables, and usage tips.
+- [MCP implementation notes](packages/cli/src/mcp/README.md): architecture and implementation details for MCP support.
+- [AGENTS.md](AGENTS.md): contributor-facing architecture, conventions, and workflow guidance.
+- [example.polkacodes.yml](example.polkacodes.yml): commented configuration example.
 
-### Reviewing Pull Requests
+## Configuration Overview
 
-To review a pull request, use the `--pr` option with the pull request number. This feature requires the [GitHub CLI](https://cli.github.com/) (`gh`) to be installed and authenticated.
-
-```bash
-# Review a pull request by number
-polka review --pr 123
-
-# Review and automatically apply feedback in a loop (up to 3 times)
-polka review --pr 123 --loop 3
-```
-
-### Reviewing Local Changes
-
-To review local changes, run the `review` command without any arguments. It will automatically detect changes in the following order:
-1. Staged changes (`git diff --staged`)
-2. Unstaged changes (`git diff`)
-
-If no local changes are found, it will fall back to reviewing the diff between the current branch and the repository's default branch (e.g., `main` or `master`). This also requires `gh`.
-
-```bash
-# Review staged or unstaged changes
-polka review
-
-# Review and apply feedback
-polka review --yes
-```
-
-### JSON Output
-
-For programmatic use, you can get the review in JSON format by adding the `--json` flag.
-
-```bash
-polka review --json
-```
-
-For more information, see the [CLI README](packages/cli/README.md).
-
-## Custom Scripts
-
-Polka Codes supports defining and executing custom automation scripts in your `.polkacodes.yml` configuration file. This allows you to create reusable TypeScript scripts and shell commands for common development tasks.
-
-### Script Types
-
-You can define four types of scripts:
-
-1. **Simple Shell Command**: A quick one-liner
-2. **Command with Description**: A shell command with metadata
-3. **TypeScript Script**: An in-process TypeScript file with full access to Polka Codes APIs
-4. **Workflow Script**: A reference to a workflow YAML file
-
-### Configuration
-
-Add scripts to your `.polkacodes.yml`:
+Polka Codes reads project configuration from `.polkacodes.yml`. Define runnable project automation under `scripts`:
 
 ```yaml
 scripts:
-  # Simple shell command
-  test: bun test
-
-  # Command with description
-  lint:
-    command: bun run lint
-    description: Run linter
-
-  # TypeScript script
-  deploy:
-    script: .polka-scripts/deploy.ts
-    description: Deploy to production
-    timeout: 300000  # 5 minutes
-    permissions:
-      fs: write
-      network: true
+  test:
+    command: bun test
+    description: Run the test suite
+  check:
+    command: bun check
+    description: Run type checking and linting
+  format:
+    command: bun fix
+    description: Format code and fix lint issues
 ```
 
-### Running Scripts
-
-```bash
-# List all available scripts
-polka run --list
-
-# Run a specific script
-polka run deploy
-
-# Run with arguments
-polka run deploy -- --production --force
-
-# Quick execution - runs script directly
-polka test  # Runs the 'test' script
-```
-
-### Creating TypeScript Scripts
-
-Generate a new script template:
-
-```bash
-polka init script my-script
-```
-
-This creates `.polka-scripts/my-script.ts` with a template:
-
-```typescript
-import { code, commit } from '@polka-codes/cli'
-
-export async function main(args: string[]) {
-  console.log('Running script: my-script')
-  console.log('Arguments:', args)
-
-  // Your automation here
-  // await code({ task: 'Add feature', interactive: false })
-  // await commit({ all: true, context: 'Feature complete' })
-
-  console.log('Script completed successfully')
-}
-
-if (import.meta.main) {
-  main(process.argv.slice(2))
-}
-```
-
-### Script Permissions
-
-TypeScript scripts support declaring permissions (currently advisory for future sandboxing):
-
-```yaml
-scripts:
-  risky-script:
-    script: .polka-scripts/risky.ts
-    permissions:
-      fs: write        # read, write, or none
-      network: true     # true or false
-      subprocess: true  # true or false
-    timeout: 60000      # Execution timeout in milliseconds
-    memory: 512         # Memory limit in MB (64-8192)
-```
-
-**Important**: TypeScript scripts currently run in-process with full permissions. Permission declarations are advisory only for future sandboxing implementation.
-
-### Built-in Commands
-
-The following command names are reserved and cannot be used for custom scripts:
-- `code`, `commit`, `pr`, `review`, `fix`, `plan`, `workflow`, `run`, `init`, `meta`
-
-## Checkpoint & Resume
-
-Polka Codes automatically creates checkpoints during agent runs, allowing you to save your work state and resume later.
-
-### Listing Checkpoints
-
-View all available checkpoints:
-
-```bash
-polka checkpoints
-```
-
-Output example:
-```
-Found 2 checkpoint(s):
-
-1. feature-complete - Jan 4, 2025, 3:00:00 PM (5m ago)
-   Completed: 10 task(s)
-
-2. initial-state - Jan 4, 2025, 2:00:00 PM (1h 5m ago)
-   Queue: 15 task(s)
-   Next: Implement user authentication
-
-Resume with:
-  bun polka continue feature-complete
-```
-
-For more details:
-
-```bash
-polka checkpoints --verbose
-```
-
-### Resuming from Checkpoints
-
-Resume from the most recent checkpoint:
-
-```bash
-polka continue
-```
-
-Resume from a specific checkpoint:
-
-```bash
-polka continue feature-complete
-```
-
-The continue command will show you:
-- What tasks were completed
-- What tasks failed
-- What tasks are pending
-- Instructions to manually restore and continue
-
-**Note**: Full automatic resume is planned for a future release. Currently, the command provides clear instructions for manual restoration.
-
-### Working Directory
-
-Checkpoints are stored in your project's `.polka/agent-state/checkpoints/` directory. Each checkpoint contains:
-- Session ID and timestamp
-- Task queue status
-- Completed and failed tasks
-- Execution history
-- Metrics and performance data
-
-## MCP Integration
-
-Polka Codes supports the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) for both consuming external tools and exposing your own workflows as MCP tools.
-
-### Consuming MCP Tools
-
-You can configure external MCP servers in your `.polkacodes.yml` to make their tools available to AI agents:
-
-```yaml
-mcpServers:
-  filesystem:
-    command: npx
-    args: ["-y", "@modelcontextprotocol/server-filesystem", "/allowed/path"]
-    tools:
-      read_file: true
-      write_file: true
-    # Optionally configure specific AI provider for tools
-    # provider: anthropic
-    # model: claude-3-5-sonnet-20241022
-
-  database:
-    command: /path/to/custom-server
-    env:
-      DATABASE_URL: "postgresql://..."
-```
-
-When MCP servers are configured, their tools are automatically exposed to AI agents in the `code`, `fix`, `plan`, and `task` workflows. Tools are named with the pattern `{serverName}/{toolName}` (e.g., `filesystem/read_file`).
-
-### Exposing Workflows via MCP Server
-
-Polka Codes can run as an MCP server, exposing your high-level workflows to Claude Code.
-
-Start the MCP server:
-
-```bash
-polka mcp-server
-```
-
-The server exposes these workflow tools:
-- `code`: Execute coding tasks
-- `review`: Review code changes
-- `plan`: Create implementation plans
-- `fix`: Fix failing tests or commands
-- `commit`: Generate commit messages
-
-**Configuration with Claude Code:**
-
-Add the MCP server to your Claude Code configuration:
-
-```bash
-claude mcp add polka polka mcp-server
-```
-
-Or manually edit `~/.claude/config.json`:
-
-```json
-{
-  "mcpServers": {
-    "polka": {
-      "command": "polka",
-      "args": ["mcp-server"]
-    }
-  }
-}
-```
-
-For detailed MCP usage instructions and configuration options, see [MCP_GUIDE.md](MCP_GUIDE.md).
-
-## Project Structure
-
-The project is organized as a monorepo with the following packages:
-
-| Package | Description |
-|---|---|
-| [`core`](/packages/core) | Core AI services, agent implementations, and tooling. |
-| [`cli`](/packages/cli) | Command-line interface for interacting with AI services. |
-| [`cli-shared`](/packages/cli-shared) | Shared utilities and types for CLI packages. |
-| [`github`](/packages/github) | GitHub integration, including the GitHub Action. |
-| [`runner`](/packages/runner) | Service for running agents and managing tasks. |
-
-## Getting Started
-
-### Prerequisites
-
-- [Bun](https://bun.sh/) (v1.0.0 or higher)
-- [ripgrep](https://github.com/BurntSushi/ripgrep#installation) (required for the file search tool)
-
-### Development Setup
-
-```bash
-# Clone the repository
-git clone https://github.com/polka-codes/polka-codes.git
-cd polka-codes
-
-# Install dependencies
-bun install
-```
-
-### Available Scripts
-
-- `bun build`: Build all packages.
-- `bun lint`: Check for linting and formatting errors.
-- `bun fix`: Automatically fix linting and formatting issues.
-- `bun check`: Run type checking and linting.
-- `bun typecheck`: Run type checking only.
-- `bun test`: Run tests across all packages.
-- `bun clean`: Remove build artifacts.
-- `bun cli`: Run the CLI in development mode.
-- `bun pr`: A shortcut for `bun cli pr`.
-- `bun commit`: A shortcut for `bun cli commit`.
-- `bun codegen`: Generate GraphQL types for the GitHub package.
-
-## Contributing
-
-If you're contributing to this project, please refer to [AGENTS.md](AGENTS.md) for:
-- Comprehensive project architecture and workflow system documentation
-- Code conventions and development guidelines
-- Tool system patterns and multi-agent architecture
-- Important implementation notes
-
-## Configuration
-
-A [`.polkacodes.yml`](.polkacodes.yml) configuration file can be used to customize the behavior of polka-codes. An example configuration file is provided in the repository as [`example.polkacodes.yml`](example.polkacodes.yml).
-
-For detailed configuration options, refer to the example file, which includes comprehensive comments for each setting.
-
-### Tool Format
-
-You can specify the format for tool integration using the `toolFormat` option in your `.polkacodes.yml` file. This setting determines how the AI model interacts with the available tools.
-
--   **`native`**: Uses the model's native tool-use capabilities via the Vercel AI SDK. More efficient and leads to better results, but not supported by all models. Check your model provider's documentation for compatibility.
-
--   **`polka-codes`** (default): Uses a custom XML-based format for tool calls. Designed to be compatible with a wide range of models but may consume more tokens compared to the `native` format.
-
-You can set the `toolFormat` globally or for specific agents or commands.
-
-Example:
-```yaml
-# .polkacodes.yml
-toolFormat: "native"
-```
+You can also configure model providers, agent rules, MCP servers, tool formatting, and file exclusions. See the [CLI configuration reference](packages/cli/README.md#configuration) and [`example.polkacodes.yml`](example.polkacodes.yml) for details.
 
 ## Environment Variables
 
-The following environment variables can be used to configure Polka Codes. Note that command line options take precedence over environment variables, which in turn take precedence over the configuration file.
+Command line options take precedence over environment variables, and environment variables take precedence over configuration files.
 
 | Variable | Description |
 |---|---|
-| `POLKA_API_PROVIDER` | Specify the default AI service provider. |
-| `POLKA_MODEL` | Specify the default AI model to use. |
+| `POLKA_API_PROVIDER` | Default AI service provider. |
+| `POLKA_MODEL` | Default AI model. |
 | `POLKA_API_KEY` | Default API key for the selected provider. |
-| `POLKA_BUDGET` | Set the budget limit for AI service usage (defaults to 1000). |
-| `ANTHROPIC_API_KEY` | API key for Anthropic Claude service. |
-| `OPENROUTER_API_KEY` | API key for OpenRouter service. |
-| `DEEPSEEK_API_KEY` | API key for DeepSeek service. |
+| `POLKA_BUDGET` | Budget limit for AI service usage. |
+| `ANTHROPIC_API_KEY` | API key for Anthropic. |
+| `OPENROUTER_API_KEY` | API key for OpenRouter. |
+| `DEEPSEEK_API_KEY` | API key for DeepSeek. |
+
+## Development
+
+### Prerequisites
+
+- [Bun](https://bun.sh/) v1.0.0 or higher.
+- [ripgrep](https://github.com/BurntSushi/ripgrep#installation), required by the file search tool.
+
+### Setup
+
+```bash
+git clone https://github.com/polka-codes/polka-codes.git
+cd polka-codes
+bun install
+```
+
+### Repository Scripts
+
+- `bun build`: build all packages.
+- `bun lint`: check linting and formatting.
+- `bun fix`: automatically fix linting and formatting issues.
+- `bun check`: run type checking and linting.
+- `bun typecheck`: run type checking only.
+- `bun test`: run tests across all packages.
+- `bun clean`: remove build artifacts.
+- `bun cli`: run the CLI in development mode.
+- `bun pr`: shortcut for `bun cli pr`.
+- `bun commit`: shortcut for `bun cli commit`.
+- `bun codegen`: generate GraphQL types for the GitHub package.
+
+## Project Structure
+
+| Package | Description |
+|---|---|
+| [`core`](packages/core) | Core AI services, agent implementations, configuration schemas, and tooling. |
+| [`cli`](packages/cli) | Command-line interface for interacting with AI services. |
+| [`cli-shared`](packages/cli-shared) | Shared utilities and types for CLI packages. |
+| [`github`](packages/github) | GitHub integration, including the GitHub Action. |
+| [`runner`](packages/runner) | Service for running agents and managing tasks. |
+
+## Contributing
+
+If you are contributing to this project, read [AGENTS.md](AGENTS.md) for project architecture, code conventions, tool system patterns, workflow guidance, and implementation notes.
 
 ## License
 
@@ -440,4 +149,5 @@ This project is licensed under the [AGPL-3.0 License](LICENSE).
 This project is heavily inspired by the [Cline](https://github.com/cline/cline) project.
 
 ---
+
 *Generated by polka.codes*

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,12 +2,12 @@
 
 [![npm version](https://img.shields.io/npm/v/@polka-codes/cli.svg)](https://www.npmjs.com/package/@polka-codes/cli)
 [![npm downloads](https://img.shields.io/npm/dm/@polka-codes/cli.svg)](https://www.npmjs.com/package/@polka-codes/cli)
-[![License](https://img.shields.io/npm/l/@polka-codes/cli.svg)](https://github.com/polkacodes/polkacodes/blob/main/LICENSE)
+[![License](https://img.shields.io/npm/l/@polka-codes/cli.svg)](https://github.com/polka-codes/polka-codes/blob/master/LICENSE)
 
 [![Bun Version](https://img.shields.io/badge/Bun-v1.0.0+-brightgreen)](https://bun.sh)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.0+-blue)](https://www.typescriptlang.org)
 
-The Polka Codes CLI provides a powerful command-line interface for interacting with AI-powered coding assistants. It offers features like code generation, implementation planning, bug fixing, and pull request reviews.
+The Polka Codes CLI is the command reference for Polka Codes. Use it to plan work, implement changes, fix failing commands, review code, manage checkpoints, run custom scripts, and create GitHub commits and pull requests.
 
 ## Installation
 
@@ -25,15 +25,25 @@ bun add -g @polka-codes/cli
 npx @polka-codes/cli "Your task description"
 ```
 
+## Requirements
+
+For normal npm, yarn, or npx usage:
+
+- `git`, required for repository-aware workflows.
+- GitHub CLI (`gh`), required for `pr` and GitHub PR review workflows.
+- `ripgrep`, required by the file search tool.
+
+For repository development or source installs, install [Bun](https://bun.sh/) v1.0.0 or higher.
+
 ## Commands
 
-The primary way to use Polka is by providing a task description directly:
+The primary way to use Polka is to provide a task description directly:
 
 ```bash
 polka "implement user authentication"
 ```
 
-The CLI will intelligently determine the best workflow to handle your request. For more specific tasks, you can use the following commands:
+The CLI chooses the best workflow for the request. Use explicit commands when you need a specific workflow.
 
 ### Core Commands
 
@@ -47,14 +57,14 @@ polka code --preview "Add login form"  # Show diff before applying
 ```
 
 **Features:**
-- Architect agent creates implementation plan
-- Coder agent implements the plan
-- Automatic fix workflow runs after implementation
-- Optional diff preview mode
+- Architect agent creates an implementation plan.
+- Coder agent implements the plan.
+- Automatic fix workflow runs after implementation.
+- Optional diff preview mode.
 
 #### `plan`
 
-Create an implementation plan for a new feature or refactor.
+Create or update an implementation plan.
 
 ```bash
 polka plan "Add user authentication"
@@ -62,56 +72,57 @@ polka plan --plan-file auth-plan.md "Update auth system"
 ```
 
 **Features:**
-- Creates detailed step-by-step plans
-- Saves to markdown files for review
-- Can update existing plans
+- Creates detailed step-by-step plans.
+- Saves plans to markdown files for review.
+- Can update existing plans.
 
 #### `fix`
 
-Automatically fix failing tests or commands by running them and letting AI fix errors.
+Run a failing command and let an agent fix the errors.
 
 ```bash
-polka fix                    # Uses default check/test scripts
-polka fix "bun test"         # Fix specific test failures
-polka fix -p "Focus on auth"  # Provide additional context
+polka fix                         # Uses configured check/test scripts
+polka fix "bun test"              # Fix specific test failures
+polka fix -p "Focus on auth"      # Same as --prompt; adds context
+polka fix --prompt "Focus on auth"
 ```
 
 **Features:**
-- Iterative fixing with bail conditions
-- Uses check/test/format scripts from `.polkacodes.yml`
-- Supports custom commands
+- Iterative fixing with bail conditions.
+- Uses check/test/format scripts from `.polkacodes.yml`.
+- Supports custom commands.
 
 #### `review`
 
-Review code changes (GitHub PR or local) with AI-powered feedback.
+Review code changes with AI-powered feedback.
 
 ```bash
 polka review                      # Review local changes
 polka review --pr 123             # Review GitHub PR
 polka review --range HEAD~5..HEAD # Review commit range
-polka review --loop 3              # Re-review until clean
+polka review --loop 3             # Re-review until clean
 polka review --json               # JSON output for automation
 ```
 
 **Features:**
-- Reviews staged changes, unstaged changes, or commit ranges
-- GitHub PR review with `gh` integration
-- Iterative remediation with `--loop`
-- Can automatically apply fixes
+- Reviews staged changes, unstaged changes, commit ranges, or GitHub PRs.
+- Uses `gh` for GitHub PR review.
+- Supports iterative remediation with `--loop`.
+- Can automatically apply fixes when requested.
 
 #### `commit`
 
-Generate a commit message based on your staged changes.
+Generate a commit message based on staged changes.
 
 ```bash
-polka commit          # Generate message for staged changes
-polka commit -a       # Stage all changes first
-polka commit --context "Fixed login bug"  # Add context
+polka commit                                # Generate message for staged changes
+polka commit -a                             # Stage all changes first
+polka commit --context "Fixed login bug"   # Add context
 ```
 
 #### `pr`
 
-Create a GitHub pull request with AI-generated title and description.
+Create a GitHub pull request with an AI-generated title and description.
 
 ```bash
 polka pr
@@ -139,9 +150,9 @@ polka checkpoints --verbose    # Show detailed info
 ```
 
 **Output shows:**
-- Checkpoint name and timestamp
-- Completed, failed, and pending tasks
-- Instructions to resume
+- Checkpoint name and timestamp.
+- Completed, failed, and pending tasks.
+- Instructions to resume.
 
 #### `continue`
 
@@ -154,15 +165,15 @@ polka continue --list             # List checkpoints in continue mode
 ```
 
 **Features:**
-- Shows task status (completed, failed, pending)
-- Provides instructions to restore state
-- Helps continue from where you left off
+- Shows task status.
+- Provides instructions to restore state.
+- Helps continue from where you left off.
 
 ### Utility Commands
 
 #### `init`
 
-Initialize Polka Codes configuration.
+Initialize Polka Codes configuration or generate templates.
 
 ```bash
 polka init                    # Create local config
@@ -186,8 +197,8 @@ polka run deploy -- --prod    # Pass arguments to script
 Manage agent skills.
 
 ```bash
-polka skills                   # List available skills
-polka skills create            # Create new skill
+polka skills                  # List available skills
+polka skills create           # Create new skill
 ```
 
 ### Advanced Commands
@@ -200,7 +211,7 @@ Start Polka Codes as an MCP server for Claude Code.
 polka mcp-server
 ```
 
-**Configure with Claude Code:**
+Configure it with Claude Code:
 
 ```bash
 claude mcp add polka polka mcp-server
@@ -219,11 +230,11 @@ Or manually edit `~/.claude/config.json`:
 }
 ```
 
-Exposes workflows as MCP tools for use with Claude Code.
+This exposes workflows such as `code`, `review`, `plan`, `fix`, and `commit` as MCP tools. See [MCP implementation notes](src/mcp/README.md) for architecture details.
 
 #### `agent`
 
-Run autonomous agent for continuous improvement.
+Run an autonomous agent for continuous improvement.
 
 ```bash
 polka agent "Fix all failing tests"
@@ -231,55 +242,39 @@ polka agent "Fix all failing tests"
 
 **Note:** This is experimental and primarily used for task discovery and planning.
 
-### Git Integration
+#### `meta`
 
-#### `commit`
-
-Generate a commit message based on your staged changes.
-
-```bash
-# Generate commit message for staged changes
-polka commit
-
-# Generate commit message with additional context
-polka commit "closes #123"
-
-# Stage all changes and commit
-polka commit -a
-```
-
-#### `pr`
-
-Create a pull request with an AI-generated title and description.
-
-```bash
-# Create PR for the current branch
-polka pr
-
-# Create PR with additional context
-polka pr "implements feature #456"
-```
+Route a natural-language request to the appropriate workflow. This is primarily an internal workflow used by the CLI when you invoke `polka "your task"`; most users do not need to run it directly.
 
 ## Configuration
 
 ### Provider Setup
 
-Polka Codes supports multiple AI providers:
+Polka Codes supports multiple AI providers. Common provider names include `deepseek`, `anthropic`, `openai`, `openrouter`, `google-vertex`, and `ollama`, depending on your installed provider configuration.
 
-1. DeepSeek (Recommended)
-2. Anthropic (Claude 3 Sonnet recommended)
-3. OpenRouter
-
-Configure your provider in `.env`:
+Configure your provider in `.env` or `.polkacodes.yml`:
 
 ```bash
-# Required
 POLKA_API_KEY=your_api_key_here
-
-# Optional - override defaults
-POLKA_API_PROVIDER=deepseek  # or anthropic, openrouter, openai
-POLKA_MODEL=deepseek-chat  # or claude-3-7-sonnet-20250219
+POLKA_API_PROVIDER=deepseek
+POLKA_MODEL=deepseek-chat
 ```
+
+You can also use provider-specific keys such as `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, and `DEEPSEEK_API_KEY`.
+
+### Environment Variables
+
+Command line options take precedence over environment variables, and environment variables take precedence over configuration files.
+
+| Variable | Description |
+|---|---|
+| `POLKA_API_PROVIDER` | Default AI service provider. |
+| `POLKA_MODEL` | Default AI model. |
+| `POLKA_API_KEY` | Default API key for the selected provider. |
+| `POLKA_BUDGET` | Budget limit for AI service usage. |
+| `ANTHROPIC_API_KEY` | API key for Anthropic. |
+| `OPENROUTER_API_KEY` | API key for OpenRouter. |
+| `DEEPSEEK_API_KEY` | API key for DeepSeek. |
 
 ### Project Configuration
 
@@ -287,71 +282,73 @@ Create `.polkacodes.yml` in your project root:
 
 ```yaml
 # AI provider settings
-defaultProvider: deepseek  # default provider
-defaultModel: deepseek-chat  # default model
+defaultProvider: deepseek
+defaultModel: deepseek-chat
 
-# Custom commands available to AI
-commands:
+# Custom scripts available to Polka and AI workflows
+scripts:
   test:
     command: bun test
-    description: Run tests. Pass file path to run specific tests.
+    description: Run tests. Pass a file path to run specific tests.
   check:
     command: bun typecheck
-    description: Run type checker
+    description: Run type checking.
   format:
     command: bun fix
-    description: Format code
+    description: Format code.
 
 # Additional rules/guidelines for AI
 rules: |
-  - Use TypeScript for all new files
-  - Follow project's existing code style
-  - Add tests for new features
+  - Use TypeScript for all new files.
+  - Follow the project's existing code style.
+  - Add tests for new features.
 ```
+
+Use `scripts` for runnable project commands. The lower-level `commands` key is reserved for per-command model settings.
 
 ### Global vs Local Configuration
 
-- Global config (`~/.config/polkacodes/config.yml`): Store API keys and default settings
-- Local config (`.polkacodes.yml`): Project-specific settings and commands
+- Global config (`~/.config/polkacodes/config.yml`): store API keys and default settings.
+- Local config (`.polkacodes.yml`): store project-specific settings, scripts, and rules.
 
 ## Features
 
-- 🤖 Multiple AI provider support
-- 🧠 Intelligent workflow execution
-- 💻 Code generation, planning, and bug fixing
-- 🔄 Git workflow integration (commit messages and PRs)
-- 🔎 Pull request reviews
-- 📊 Project-specific configuration and commands
-- 🔑 Secure API key management
-- 📝 Detailed logging with `--verbose`
+- Multiple AI provider support.
+- Intelligent workflow execution.
+- Code generation, planning, and bug fixing.
+- Git workflow integration for commit messages and PRs.
+- Pull request reviews.
+- Project-specific configuration and scripts.
+- Secure API key management.
+- Detailed logging with `--verbose`.
 
 ## Usage Tips
 
-1.  For general tasks, let Polka figure it out:
-    ```bash
-    polka "add a dark mode toggle to the settings page"
-    ```
+1. Let Polka choose the workflow for general tasks:
+   ```bash
+   polka "add a dark mode toggle to the settings page"
+   ```
 
-2.  Create a plan before implementing a large feature:
-    ```bash
-    polka plan "migrate the frontend from Vue to React"
-    ```
+2. Create a plan before implementing a large feature:
+   ```bash
+   polka plan "migrate the frontend from Vue to React"
+   ```
 
-3.  Combine with your git workflow:
-    ```bash
-    git add . && polka commit && polka pr
-    ```
+3. Combine with your git workflow:
+   ```bash
+   git add . && polka commit && polka pr
+   ```
 
-4.  Get help with a failing test:
-    ```bash
-    polka fix "bun test tests/checkout.test.ts" --verbose
-    ```
+4. Add context when fixing a failing command:
+   ```bash
+   polka fix "bun test tests/checkout.test.ts" --prompt "Focus on checkout totals" --verbose
+   ```
 
-## Requirements
+## See Also
 
-- Bun (v1.0.0+)
-- `git` (for `commit` and `pr` commands)
-- `GitHub CLI (gh)` (for `pr` command)
+- [Root README](../../README.md) for the project overview.
+- [MCP implementation notes](src/mcp/README.md) for MCP architecture details.
+- [example.polkacodes.yml](../../example.polkacodes.yml) for a commented configuration example.
 
 ---
 

--- a/packages/cli/src/mcp/README.md
+++ b/packages/cli/src/mcp/README.md
@@ -1,146 +1,107 @@
 # MCP (Model Context Protocol) Integration
 
-This directory contains the implementation of MCP (Model Context Protocol) support for polka-codes, enabling the CLI to connect to external MCP servers and use their tools/resources in AI workflows.
+This directory contains the implementation of MCP support for Polka Codes. The CLI can connect to external MCP servers, register their tools, and expose selected Polka workflows through `polka mcp-server`.
+
+For user-facing CLI usage, configuration examples, and command syntax, see the [CLI README](../../README.md#mcp-server). This document focuses on implementation details for contributors.
 
 ## Architecture
 
 ### Core Components
 
-1. **`types.ts`** - Type definitions for MCP protocol
-   - `McpTool`: Tool definition from an MCP server
-   - `McpResource`: Resource definition from an MCP server
-   - `McpServerConfig`: Configuration for MCP servers
-   - `IMcpClient`: Interface for MCP client implementations
+1. **`types.ts`** - Type definitions for MCP protocol data.
+   - `McpTool`: tool definition from an MCP server.
+   - `McpResource`: resource definition from an MCP server.
+   - `McpServerConfig`: configuration for MCP servers.
+   - `IMcpClient`: interface for MCP client implementations.
 
-2. **`transport.ts`** - Transport layer for MCP communication
-   - `StdioTransport`: Handles stdio-based communication with local MCP servers
-   - JSON-RPC message format implementation
-   - Process management and message parsing
+2. **`transport.ts`** - Transport layer for MCP communication.
+   - `StdioTransport`: stdio-based communication with local MCP servers.
+   - JSON-RPC message format implementation.
+   - Process management and message parsing.
 
-3. **`client.ts`** - MCP client implementation
-   - `McpClient`: Main client class for connecting to MCP servers
-   - Tool listing and execution
-   - Resource reading
-   - Error handling and connection management
+3. **`client.ts`** - MCP client implementation.
+   - `McpClient`: main client class for connecting to MCP servers.
+   - Tool listing and execution.
+   - Resource reading.
+   - Error handling and connection management.
 
-4. **`manager.ts`** - MCP server manager
-   - `McpManager`: Manages multiple MCP server connections
-   - Tool registration and routing
-   - Connection lifecycle management
+4. **`manager.ts`** - MCP server manager.
+   - `McpManager`: manages multiple MCP server connections.
+   - Tool registration and routing.
+   - Connection lifecycle management.
 
-5. **`tools.ts`** - AI SDK integration
-   - `createMcpTools()`: Converts MCP tools to AI SDK ToolSet format
-   - Tool name mapping and execution
+5. **`tools.ts`** - AI SDK integration.
+   - `createMcpTools()`: converts MCP tools to AI SDK `ToolSet` format.
+   - Tool name mapping and execution.
 
-6. **`errors.ts`** - MCP-specific error classes
-   - `McpConnectionError`: Server connection failures
-   - `McpTimeoutError`: Request timeouts
-   - `McpProtocolError`: Protocol violations
-   - `McpToolError`: Tool execution failures
+6. **`errors.ts`** - MCP-specific error classes.
+   - `McpConnectionError`: server connection failures.
+   - `McpTimeoutError`: request timeouts.
+   - `McpProtocolError`: protocol violations.
+   - `McpToolError`: tool execution failures.
 
-## Configuration
+## Configuration Source of Truth
 
-MCP servers are configured in `~/.config/polkacodes/config.yml` or `.polkacodes.yml`:
+MCP servers are configured in `~/.config/polkacodes/config.yml` or `.polkacodes.yml` under `mcpServers`. The canonical user-facing example lives in the [CLI configuration reference](../../README.md#configuration). Keep that file as the command and config reference so examples do not drift across documents.
 
-```yaml
-mcpServers:
-  filesystem:
-    command: "npx"
-    args: ["-y", "@modelcontextprotocol/server-filesystem", "/allowed/path"]
-    tools:
-      read_file: true
-      write_file: true
-      create_directory: false
+At runtime, configured MCP servers are loaded during workflow startup. Their tools are registered with the name format `<server-name>/<tool-name>`, for example `filesystem/read_file`.
 
-  github:
-    command: "npx"
-    args: ["-y", "@modelcontextprotocol/server-github"]
-    env:
-      GITHUB_TOKEN: "${GITHUB_TOKEN}"
-    tools:
-      create_issue: true
-      create_pull_request: true
+## Server Mode
+
+The `polka mcp-server` command starts Polka Codes as an MCP server for clients such as Claude Code. It exposes high-level workflows as tools, including `code`, `review`, `plan`, `fix`, and `commit`.
+
+```bash
+polka mcp-server
 ```
 
-## Usage
-
-### Automatic Tool Registration
-
-When MCP servers are configured, polka-codes automatically:
-1. Connects to all configured servers at workflow startup
-2. Lists available tools from each server
-3. Registers tools with the format `<server-name>/<tool-name>`
-4. Makes tools available to AI agents during workflow execution
-
-### Tool Calling
-
-MCP tools are called automatically by the AI agent when needed. The tool naming convention is:
-- `<server-name>/<tool-name>` (e.g., `filesystem/read_file`)
-
-### Tool-Level Configuration
-
-Individual tools can be enabled/disabled:
-```yaml
-mcpServers:
-  myserver:
-    command: "npx"
-    args: ["-y", "@modelcontextprotocol/server-example"]
-    tools:
-      specific_tool: true          # enabled
-      another_tool: false         # disabled
-      custom_tool:                # enabled with custom model
-        provider: anthropic
-        model: claude-3-5-sonnet-20241022
-```
+See the [CLI README](../../README.md#mcp-server) for Claude Code setup examples.
 
 ## Error Handling
 
-MCP integration includes comprehensive error handling:
-- Connection failures are logged but don't prevent other servers from connecting
-- Tool execution errors are reported to the user with actionable messages
-- Timeouts and retries are handled appropriately
-- All MCP errors extend the base `McpError` class
+MCP integration includes targeted error handling:
+
+- Connection failures are logged without preventing other configured servers from connecting.
+- Tool execution errors are reported with actionable messages.
+- Timeouts and retries are handled by the MCP client layer.
+- MCP-specific errors extend the base `McpError` class.
 
 ## Security Considerations
 
-1. **Path Restrictions**: Filesystem MCP servers should be restricted to allowed paths
-2. **Authentication**: Support for API keys and tokens via environment variables
-3. **Sandboxing**: MCP servers run as separate processes with limited permissions
-4. **Tool-Level Control**: Enable/disable specific tools per server
+1. **Path restrictions**: filesystem MCP servers should be restricted to allowed paths.
+2. **Authentication**: API keys and tokens should be passed through environment variables.
+3. **Sandboxing**: MCP servers run as separate processes with their own permissions.
+4. **Tool-level control**: specific tools can be enabled or disabled per server.
 
 ## Implementation Status
 
-✅ Core MCP client (stdio transport)
-✅ Configuration schema
-✅ Tool registration and execution
-✅ Error handling
-✅ Connection management
-✅ Integration with workflow execution
-⏳ SSE transport (future)
-⏳ Resource protocol support (future)
-⏳ Prompts protocol support (future)
+- Core MCP client with stdio transport: complete.
+- Configuration schema: complete.
+- Tool registration and execution: complete.
+- Error handling: complete.
+- Connection management: complete.
+- Integration with workflow execution: complete.
+- SSE transport: future.
+- Resource protocol support: future.
+- Prompts protocol support: future.
+- Dynamic tool discovery: future.
+- Tool definition caching: future.
+- Connection pooling: future.
 
 ## Example MCP Servers
 
-Official MCP servers from the community:
-- `@modelcontextprotocol/server-filesystem` - File system operations
-- `@modelcontextprotocol/server-github` - GitHub integration
-- `@modelcontextprotocol/server-postgres` - PostgreSQL database
-- `@modelcontextprotocol/server-brave-search` - Web search
-- And many more at https://github.com/modelcontextprotocol
+Official and community MCP servers include:
+
+- `@modelcontextprotocol/server-filesystem` - file system operations.
+- `@modelcontextprotocol/server-github` - GitHub integration.
+- `@modelcontextprotocol/server-postgres` - PostgreSQL database access.
+- `@modelcontextprotocol/server-brave-search` - web search.
+
+See https://github.com/modelcontextprotocol for more servers.
 
 ## Testing
 
 Run MCP-specific tests:
+
 ```bash
 bun test packages/cli/src/mcp/manager.test.ts
 ```
-
-## Future Enhancements
-
-1. **SSE Transport**: Support for remote MCP servers via Server-Sent Events
-2. **Resource Protocol**: Full support for MCP resource reading
-3. **Prompts Protocol**: Support for prompt templates from MCP servers
-4. **Dynamic Tool Discovery**: Automatic discovery and registration of MCP tools
-5. **Tool Caching**: Cache tool definitions for faster startup
-6. **Connection Pooling**: Reuse connections across workflows


### PR DESCRIPTION
## Summary

- Reworked the root README into a concise project overview with links to canonical docs.
- Updated the CLI README to be the command and configuration reference, including requirements, provider/env-var guidance, `scripts` configuration, and non-duplicated git workflow docs.
- Clarified the MCP README as contributor-focused implementation notes and linked user-facing MCP usage back to the CLI README.

## Validation

- Docs-only change; no code or generated files changed.
- Reviewed the changed Markdown for internal link consistency and alignment with the current config schema (`scripts` for runnable project automation).